### PR TITLE
Add filter before we compile a TimberResponse

### DIFF
--- a/src/Http/Responses/TimberResponse.php
+++ b/src/Http/Responses/TimberResponse.php
@@ -10,6 +10,8 @@ class TimberResponse extends HtmlResponse
 {
     public function __construct($twigTemplate, $context, $status = 200, array $headers = [])
     {
+        $context = apply_filters('timber_response_before_compile', $context, $twigTemplate, $status, $headers);
+        
         $template = Timber::compile($twigTemplate, $context);
 
         if ($template === false) {


### PR DESCRIPTION
Some context: I wanted to add the twig template used as a class to the body. This is the only place that knows about both.