### PR TITLE
Fix Timber Post ID default parameter

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -15,7 +15,7 @@ class Post extends TimberPost
         Macroable::__callStatic as __macroableCallStatic;
     }
 
-    public function __construct($id = false, $preventTimberInit = false)
+    public function __construct($id = null, $preventTimberInit = false)
     {
         /**
          * There are occasions where we do not want the bootstrap the data. At the moment this is


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Timber [default `$pid` value passed to `Timber\Post` is `null`](https://github.com/timber/timber/blob/8666531adff9a59c1bbbd18d4fb18acaf2250456/lib/Post.php#L180)

This value [is very important to guess which post to retrieve](https://github.com/timber/timber/blob/8666531adff9a59c1bbbd18d4fb18acaf2250456/lib/Post.php#L232-L259) and does not behave the same when set to `false`. 

Does this close any currently open issues?
------------------------------------------

No.

Any relevant logs, error output, etc?
-------------------------------------

No.

Any other comments?
-------------------

Stumbled upon this issue while trying to get the static "Posts page" content which returns both a collection of posts (latest posts) and a single page (static posts page).

```php
// in my controller
use Rareloop\Lumberjack\Post;
use Rareloop\Lumberjack\Page;
// ...
$context['static_page'] = new Page();
$context['posts'] = new Post::all()();
// ...
```

In this example, `$context['static_page'] === $context['posts'][0]` but whouldn't.

