### PR TITLE
Add session garbage collection

### DIFF
--- a/src/Providers/SessionServiceProvider.php
+++ b/src/Providers/SessionServiceProvider.php
@@ -21,6 +21,10 @@ class SessionServiceProvider extends ServiceProvider
     {
         add_action('init', function () {
             $this->session->start();
+
+            if ($this->shouldGarbageCollect()) {
+                $this->session->collectGarbage();
+            }
         });
 
         // Due to the way we handle WordPressControllers sometimes the `send_headers` action is
@@ -55,7 +59,7 @@ class SessionServiceProvider extends ServiceProvider
             $this->storePreviousUrlToSession();
         });
     }
-    
+
     private function storePreviousUrlToSession()
     {
         if (!Helpers::app()->has('request')) {
@@ -69,5 +73,16 @@ class SessionServiceProvider extends ServiceProvider
         }
 
         $this->session->save();
+    }
+
+    private function shouldGarbageCollect()
+    {
+        $lottery = Config::get('session.lottery');
+
+        if (!is_array($lottery) || count($lottery) < 2 || !is_numeric($lottery[0]) || !is_numeric($lottery[1])) {
+            $lottery = [2, 100];
+        }
+
+        return random_int(1, $lottery[1]) <= $lottery[0];
     }
 }

--- a/src/Providers/SessionServiceProvider.php
+++ b/src/Providers/SessionServiceProvider.php
@@ -23,7 +23,7 @@ class SessionServiceProvider extends ServiceProvider
             $this->session->start();
 
             if ($this->shouldGarbageCollect()) {
-                $this->session->collectGarbage();
+                $this->session->collectGarbage(Config::get('session.lifetime', 120));
             }
         });
 

--- a/src/Session/Store.php
+++ b/src/Session/Store.php
@@ -231,4 +231,9 @@ class Store
     {
         return $this->get('_previous.url');
     }
+
+    public function collectGarbage(int $lifetime)
+    {
+        return $this->handler->gc($lifetime);
+    }
 }

--- a/tests/Unit/Session/StoreTest.php
+++ b/tests/Unit/Session/StoreTest.php
@@ -365,4 +365,16 @@ class StoreTest extends TestCase
 
         $this->assertSame('/a/valid/route', $store->previousUrl());
     }
+
+    /** @test */
+    public function can_garbage_collect()
+    {
+        $lifetime = 1234;
+        $handler = Mockery::mock(NullSessionHandler::class . '[gc]');
+        $handler->shouldReceive('gc')->with($lifetime)->once();
+
+        $store = new Store('session-name', $handler, 'session-id');
+
+        $store->collectGarbage($lifetime);
+    }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Makes lumberjack call the Garbage Collection method on the Session handler on a probability basis. This will reduce the number of redundant session files that are found on a server.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No
