### PR TITLE
Add custom taxonomy support

### DIFF
--- a/src/Exceptions/TaxonomyRegistrationException.php
+++ b/src/Exceptions/TaxonomyRegistrationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rareloop\Lumberjack\Exceptions;
+
+class TaxonomyRegistrationException extends \Exception
+{
+
+}

--- a/src/Providers/CustomTaxonomyServiceProvider.php
+++ b/src/Providers/CustomTaxonomyServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rareloop\Lumberjack\Providers;
+
+use Rareloop\Lumberjack\Config;
+
+class CustomTaxonomyServiceProvider extends ServiceProvider {
+  public function boot(Config $config) {
+    $taxonomiesToRegister = $config->get('taxonomies.register');
+
+    foreach ($taxonomiesToRegister as $taxonomy) {
+      $taxonomy::register();
+    }
+  }
+}

--- a/src/Term.php
+++ b/src/Term.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Rareloop\Lumberjack;
+
+use Rareloop\Lumberjack\Exceptions\TaxonomyRegistrationException;
+use Spatie\Macroable\Macroable;
+use Timber\Term as TimberTerm;
+use Timber\Timber;
+
+class Term extends TimberTerm
+{
+    use Macroable {
+        Macroable::__call as __macroableCall;
+        Macroable::__callStatic as __macroableCallStatic;
+    }
+
+    public function __construct($tid = null, $tax = '', $preventTimberInit = false)
+    {
+        /**
+         * There are occasions where we do not want the bootstrap the data. At the moment this is
+         * designed to make Query Scopes possible
+         */
+        if (!$preventTimberInit) {
+            parent::__construct($tid, $tax);
+        }
+    }
+
+    public function __call($name, $arguments)
+    {
+        if (static::hasMacro($name)) {
+            return $this->__macroableCall($name, $arguments);
+        }
+
+        return parent::__call($name, $arguments);
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        if (static::hasMacro($name)) {
+            return static::__macroableCallStatic($name, $arguments);
+        }
+
+        trigger_error('Call to undefined method '.__CLASS__.'::'.$name.'()', E_USER_ERROR);
+    }
+
+    /**
+     * Return the key used to register the taxonomy with WordPress
+     * First parameter of the `register_taxonomy` function:
+     * https://developer.wordpress.org/reference/functions/register_taxonomy/
+     *
+     * @return string
+     */
+    public static function getTaxonomyType()
+    {
+        return null;
+    }
+
+    /**
+     * Return the object type which use this taxonomy.
+     * Second parameter of the `register_taxonomy` function:
+     * https://developer.wordpress.org/reference/functions/register_taxonomy/
+     *
+     * @return array|null
+     */
+    public static function getTaxonomyObjectTypes()
+    {
+        return ['post'];
+    }
+
+    /**
+     * Return the config to use to register the taxonomy with WordPress
+     * Third parameter of the `register_taxonomy` function:
+     * https://developer.wordpress.org/reference/functions/register_taxonomy/
+     *
+     * @return array|null
+     */
+    protected static function getTaxonomyConfig()
+    {
+        return null;
+    }
+
+    /**
+     * Register this PostType with WordPress
+     *
+     * @return void
+     */
+    public static function register()
+    {
+        $taxonomyType = static::getTaxonomyType();
+        $taxonomyObjectTypes = static::getTaxonomyObjectTypes();
+        $config = static::getTaxonomyConfig();
+
+        if (empty($taxonomyType)) {
+            throw new TaxonomyRegistrationException('Taxonomy type not set');
+        }
+
+        if (empty($taxonomyObjectTypes)) {
+            throw new TaxonomyRegistrationException('Taxonomy object type not set');
+        }
+
+        if (empty($config)) {
+            throw new TaxonomyRegistrationException('Config not set');
+        }
+
+        register_taxonomy($taxonomyType, $taxonomyObjectTypes, $config);
+    }
+
+    /**
+     * Get all terms of this taxonomy
+     *
+     * @param  string $orderby Field(s) to order terms by (defaults to term_order)
+     * @param  string $order Whether to order terms in ascending or descending order (defaults to ASC)
+     * @return Illuminate\Support\Collection
+     */
+    public static function all($orderby = 'term_order', $order = 'ASC')
+    {
+        $order = strtoupper($order);
+
+        $args = [
+            'orderby'       => $orderby,
+            'order'         => $order,
+        ];
+
+        return static::query($args);
+    }
+
+
+    /**
+     * Convenience function that takes a standard set of WP_Term_Query arguments but mixes it with
+     * arguments that mean we're selecting the right taxonomy type
+     *
+     * @param  array $args standard WP_Term_Query array
+     * @return Illuminate\Support\Collection
+     */
+    public static function query($args = null)
+    {
+        $args = is_array($args) ? $args : [];
+
+        // Set the correct post type
+        $args = array_merge($args, ['taxonomy' => static::getTaxonomyType()]);
+
+        return static::terms($args);
+    }
+
+    /**
+     * Raw query function that uses the arguments provided to make a call to Timber::get_terms
+     * and casts the returning data in instances of ourself.
+     *
+     * @param  array $args standard WP_Query array
+     * @return Illuminate\Support\Collection
+     */
+    private static function terms($args = null)
+    {
+        return collect(Timber::get_terms($args, [], get_called_class()));
+    }
+}

--- a/tests/Unit/Providers/CustomTaxonomyServiceProviderTest.php
+++ b/tests/Unit/Providers/CustomTaxonomyServiceProviderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Rareloop\Lumberjack\Application;
+use Rareloop\Lumberjack\Config;
+use Rareloop\Lumberjack\Term;
+use Rareloop\Lumberjack\Providers\CustomTaxonomyServiceProvider;
+use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
+
+class CustomTaxonomyServiceProviderTest extends TestCase
+{
+    use BrainMonkeyPHPUnitIntegration;
+
+    /** @test */
+    public function should_call_register_taxonomy_for_each_configured_taxonomy()
+    {
+        $app = new Application(__DIR__ . '/..');
+
+        $config = new Config;
+
+        $config->set('taxonomies.register', [
+            CustomTaxonomy1::class,
+            CustomTaxonomy2::class,
+        ]);
+
+        Functions\expect('register_taxonomy')
+            ->times(2);
+
+        $provider = new CustomTaxonomyServiceProvider($app);
+        $provider->boot($config);
+    }
+}
+
+class CustomTaxonomy1 extends Term
+{
+    public static function getTaxonomyType()
+    {
+        return 'custom_taxonomy_1';
+    }
+
+    public static function getTaxonomyObjectTypes()
+    {
+        return ['post'];
+    }
+
+    protected static function getTaxonomyConfig()
+    {
+        return [
+            'not' => 'empty',
+        ];
+    }
+}
+
+class CustomTaxonomy2 extends Term
+{
+    public static function getTaxonomyType()
+    {
+        return 'custom_taxonomy_1';
+    }
+
+    public static function getTaxonomyObjectTypes()
+    {
+        return ['post'];
+    }
+
+    protected static function getTaxonomyConfig()
+    {
+        return [
+            'not' => 'empty',
+        ];
+    }
+}

--- a/tests/Unit/TermTest.php
+++ b/tests/Unit/TermTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test;
+
+use Brain\Monkey\Functions;
+use Illuminate\Support\Collection;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Rareloop\Lumberjack\Term;
+use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
+use Timber\Timber;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * The above is required as we're using alias mocks which persist between tests
+ * https://laracasts.com/discuss/channels/testing/mocking-a-class-persists-over-tests/replies/103075
+ */
+class TermTest extends TestCase
+{
+    use BrainMonkeyPHPUnitIntegration;
+
+    /** @test */
+    public function register_function_calls_register_taxonomy_when_taxonomy_type_and_config_are_provided()
+    {
+        Functions\expect('register_taxonomy')
+            ->once()
+            ->with(RegisterableTaxonomyType::getTaxonomyType(), RegisterableTaxonomyType::getTaxonomyObjectTypes(), RegisterableTaxonomyType::getPrivateConfig());
+
+        RegisterableTaxonomyType::register();
+    }
+
+    /**
+     * @test
+     * @expectedException     Rareloop\Lumberjack\Exceptions\TaxonomyRegistrationException
+     */
+    public function register_function_throws_exception_if_taxonomy_type_is_not_provided()
+    {
+        UnregisterableTaxonomyWithoutTaxonomyType::register();
+    }
+
+    /**
+     * @test
+     * @expectedException     Rareloop\Lumberjack\Exceptions\TaxonomyRegistrationException
+     */
+    public function register_function_throws_exception_if_config_is_not_provided()
+    {
+        UnregisterableTaxonomyWithoutConfig::register();
+    }
+
+    /**
+     * @test
+     */
+    public function query_defaults_to_current_taxonomy_type()
+    {
+        $args = [
+            'show_admin_column' => true,
+        ];
+        $maybe_args = [];
+
+        $timber = Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('get_terms')->withArgs([
+            array_merge($args, [
+                'taxonomy' => Term::getTaxonomyType(),
+            ]),
+            $maybe_args,
+            Term::class,
+        ])->once();
+
+        $terms = Term::query($args);
+
+        $this->assertInstanceOf(Collection::class, $terms);
+    }
+
+    /**
+     * @test
+     */
+    public function query_ignores_passed_in_taxonomy()
+    {
+        $args = [
+            'taxonomy' => 'something-else',
+            'show_admin_column' => true,
+        ];
+        $maybe_args = [];
+
+        $timber = Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('get_terms')->withArgs([
+            array_merge($args, [
+                'taxonomy' => Term::getTaxonomyType(),
+                'show_admin_column' => true,
+            ]),
+            $maybe_args,
+            Term::class,
+        ])->once();
+
+        $terms = Term::query($args);
+
+        $this->assertInstanceOf(Collection::class, $terms);
+    }
+
+    /**
+     * @test
+     */
+    public function term_subclass_query_has_correct_taxonomy_type()
+    {
+        $args = [
+            'show_admin_column' => true,
+        ];
+        $maybe_args = [];
+
+        $timber = Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('get_terms')->withArgs([
+            Mockery::subset([
+                'taxonomy' => RegisterableTaxonomyType::getTaxonomyType(),
+            ]),
+            $maybe_args,
+            RegisterableTaxonomyType::class,
+        ])->once();
+
+        $terms = RegisterableTaxonomyType::query($args);
+
+        $this->assertInstanceOf(Collection::class, $terms);
+    }
+
+    /**
+     * @test
+     */
+    public function all_defaults_to_ordered_by_term_order_ascending()
+    {
+        $maybe_args = [];
+        $timber = Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('get_terms')->withArgs([
+            Mockery::subset([
+                'orderby' => 'term_order',
+                'order' => 'ASC',
+            ]),
+            $maybe_args,
+            Term::class,
+        ])->once();
+
+        $terms = Term::all();
+
+        $this->assertInstanceOf(Collection::class, $terms);
+    }
+
+
+    /**
+     * @test
+     */
+    public function all_can_have_order_set()
+    {
+        $maybe_args = [];
+        $timber = Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('get_terms')->withArgs([
+            Mockery::subset([
+                'orderby' => 'slug',
+                'order' => 'DESC',
+            ]),
+            $maybe_args,
+            Term::class,
+        ])->once();
+
+        $terms = Term::all('slug', 'DESC');
+
+        $this->assertInstanceOf(Collection::class, $terms);
+    }
+
+    /**
+     * @test
+     */
+    public function can_extend_term_behaviour_with_macros()
+    {
+        Term::macro('testFunctionAddedByMacro', function () {
+            return 'abc123';
+        });
+
+        $term = new Term(false, '', true);
+
+        $this->assertSame('abc123', $term->testFunctionAddedByMacro());
+        $this->assertSame('abc123', Term::testFunctionAddedByMacro());
+    }
+
+    /**
+     * @test
+     */
+    public function macros_set_correct_this_context_on_instances()
+    {
+        Term::macro('testFunctionAddedByMacro', function () {
+            return $this->dummyData();
+        });
+
+        $term = new Term(false, '', true);
+        $term->dummyData = 'abc123';
+
+        $this->assertSame('abc123', $term->testFunctionAddedByMacro());
+    }
+
+    /**
+     * @test
+     */
+    public function can_extend_term_behaviour_with_mixin()
+    {
+        Term::mixin(new TermMixin);
+
+        $term = new Term(false, '', true);
+
+        $this->assertSame('abc123', $term->testFunctionAddedByMixin());
+    }
+}
+
+class TermMixin
+{
+    function testFunctionAddedByMixin()
+    {
+	return function() {
+	    return 'abc123';
+	};
+    }
+}
+
+class RegisterableTaxonomyType extends Term
+{
+    public static function getTaxonomyType() : string
+    {
+        return 'registerable_taxonomy_type';
+    }
+
+    public static function getTaxonomyObjectTypes() : array
+    {
+        return ['post'];
+    }
+
+    protected static function getTaxonomyConfig() : array
+    {
+        return [
+            'hierarchical' => true,
+            'labels' => [
+                'name' => 'Tags',
+                'singular_name' => 'Tag'
+            ],
+            'show_ui' => true,
+            'show_admin_column' => true,
+            'query_var' => true,
+            'rewrite' => [
+                'slug' => 'the-tags'
+            ],
+        ];
+    }
+
+    public static function getPrivateConfig()
+    {
+        return self::getTaxonomyConfig();
+    }
+}
+
+class UnregisterableTaxonomyWithoutTaxonomyType extends Term
+{
+    protected static function getTaxonomyConfig() : array
+    {
+        return [
+            'labels' => [
+                'name' => 'Groups',
+                'singular_name' => 'Group'
+            ],
+            'public' => true,
+            'has_archive' => false,
+            'supports' => ['title', 'revisions'],
+            'menu_icon' => 'dashicons-groups',
+            'rewrite' => [
+                'slug' => 'group',
+            ],
+        ];
+    }
+}
+
+class UnregisterableTaxonomyWithoutConfig extends Term
+{
+    public static function getTaxonomyType() : string
+    {
+        return 'taxonomy_type';
+    }
+}


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
As [discussed here](https://github.com/Rareloop/lumberjack/issues/16) this adds support for custom taxonomy. I took the same structure and way of doing things as the custom "Post" types so it should be consistent with this.

Does this close any currently open issues?
------------------------------------------
Yes, it should fixes https://github.com/Rareloop/lumberjack/issues/16

Any relevant logs, error output, etc?
-------------------------------------
No :) and all added test are ✔

Any other comments?
-------------------
We will add Lumberjack to our base theme and taxonomies is a must.  Let me know if I need to make some changes, I would be more than happy to help with this feature : )

And once it's merged I will make the required changes to document it here with a pull request https://github.com/Rareloop/lumberjack-docs