### PR TITLE
Allow dot syntax when checking if a session has a value

### DIFF
--- a/src/Session/Store.php
+++ b/src/Session/Store.php
@@ -89,7 +89,7 @@ class Store
 
     public function has($key)
     {
-        return Arr::exists($this->attributes, $key);
+        return Arr::has($this->attributes, $key);
     }
 
     public function pull($key)


### PR DESCRIPTION
Given:
```php
session()->put([
    'foo' => [
        'bar' => 123,
    ],
]);
```

I expected `session()->has('foo.bar')` to return `true`, however it returns `false` because it currently doesn't support dot syntax.

This MR is to allow dot syntax for the `has` method on the session store object.