### PR TITLE
Check `logger` is registered

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -28,7 +28,7 @@ class Handler implements HandlerInterface
             return;
         }
 
-        if ($this->app->has('logger') {
+        if ($this->app->has('logger')) {
             $logger = $this->app->get('logger');
             $logger->error($e);
         }


### PR DESCRIPTION
There are times that exceptions may be thrown early on in the bootstrapping phase, before the Logger has been registered but after the exception handler is added. At the moment this presents an unhelpful error like:

```
PHP Fatal error:  Uncaught DI\NotFoundException: No entry or class found for 'logger' in /pathremoved/vendor/php-di/php-di/src/DI/Container.php:128
```

This PR should prevent this case occurring and allow the handler to deal with the exception even if the Logger isn't registered.