### PR TITLE
Report throwables

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -35,9 +35,9 @@ class Handler implements HandlerInterface
         }
     }
 
-    public function render(ServerRequestInterface $request, Exception $e): ResponseInterface
+    public function render(ServerRequestInterface $request, Throwable $e): ResponseInterface
     {
-        $e = FlattenException::create($e);
+        $e = FlattenException::createFromThrowable($e);
 
         $handler = new SymfonyExceptionHandler(Config::get('app.debug', false));
 

--- a/src/Exceptions/HandlerInterface.php
+++ b/src/Exceptions/HandlerInterface.php
@@ -11,5 +11,5 @@ interface HandlerInterface
 {
     public function report(Throwable $e);
 
-    public function render(ServerRequestInterface $request, Exception $e): ResponseInterface;
+    public function render(ServerRequestInterface $request, Throwable $e): ResponseInterface;
 }

--- a/tests/Unit/Exceptions/HandlerTest.php
+++ b/tests/Unit/Exceptions/HandlerTest.php
@@ -82,6 +82,23 @@ class HandlerTest extends TestCase
     }
 
     /** @test */
+    public function render_should_return_an_html_response_for_throwables()
+    {
+        $app = new Application;
+        FacadeFactory::setContainer($app);
+        $config = new Config;
+        $config->set('app.debug', true);
+        $app->bind('config', $config);
+
+        $exception = new \TypeError('Test Type Error');
+        $handler = new Handler($app);
+
+        $response = $handler->render(new ServerRequest, $exception);
+
+        $this->assertInstanceOf(HtmlResponse::class, $response);
+    }
+
+    /** @test */
     public function render_should_return_an_html_response_when_debug_is_disabled()
     {
         $app = new Application;


### PR DESCRIPTION
Rather than only allowing `Exception`s in the `report` and `render` methods in the exception handler, allow anything that is `Throwable` (e.g. `TypeError`)