### PR TITLE
Migrate `tightenco/collect` to `illuminate/collections`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "monolog/monolog": "^2.0",
         "http-interop/response-sender": "^1.0",
         "symfony/debug": "^4.1",
-        "illuminate/collections": "^8.0.0||^9.0.0",
+        "illuminate/collections": "^8.53.1||^9.0.0",
         "statamic/stringy": "^3.1.3",
         "laminas/laminas-diactoros": "^2.4",
         "rareloop/psr7-server-request-extension": "^2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "monolog/monolog": "^2.0",
         "http-interop/response-sender": "^1.0",
         "symfony/debug": "^4.1",
-        "tightenco/collect": "^5.6.0",
+        "illuminate/collections": "^8.0.0||^9.0.0",
         "statamic/stringy": "~3.1.0",
         "laminas/laminas-diactoros": "^2.4",
         "rareloop/psr7-server-request-extension": "^2.1.0",
@@ -22,7 +22,8 @@
         "spatie/macroable": "^1.0",
         "mindplay/middleman": "^3.0.3",
         "psr/log": "^1.1",
-        "laminas/laminas-zendframework-bridge": "^1.4"
+        "laminas/laminas-zendframework-bridge": "^1.4",
+        "symfony/var-dumper": "^5.0||^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
@@ -38,7 +39,10 @@
     "autoload": {
         "psr-4": {
             "Rareloop\\Lumberjack\\": "src"
-        }
+        },
+        "files": [
+            "src/alias.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/alias.php
+++ b/src/alias.php
@@ -1,0 +1,15 @@
+<?php
+
+// Backwards compatibilty alias for Tightenco collections
+$aliases = [
+    Illuminate\Support\Collection::class => Tightenco\Collect\Support\Collection::class,
+    Illuminate\Support\Arr::class => Tightenco\Collect\Support\Arr::class,
+    Illuminate\Support\HigherOrderCollectionProxy::class => Tightenco\Collect\Support\HigherOrderCollectionProxy::class,
+    Illuminate\Support\Traits\Macroable::class => Tightenco\Collect\Support\Traits\Macroable::class,
+];
+
+foreach ($aliases as $illuminate => $tighten) {
+    if (!class_exists($tighten) && !interface_exists($tighten) && !trait_exists($tighten)) {
+        class_alias($illuminate, $tighten);
+    }
+}

--- a/tests/Unit/CollectionsTest.php
+++ b/tests/Unit/CollectionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test;
+
+use PHPUnit\Framework\TestCase;
+use Rareloop\Lumberjack\Config;
+use Tightenco\Collect\Support\Collection;
+
+class CollectionsTest extends TestCase
+{
+    /** @test */
+    public function can_create_collection_with_tighten_namespace()
+    {
+        $collection = new \Tightenco\Collect\Support\Collection(['foo', 'bar']);
+        $this->assertEquals(2, $collection->count());
+    }
+
+    /** @test */
+    public function can_create_collection_with_illuminate_namespace()
+    {
+        $collection = new \Illuminate\Support\Collection(['foo', 'bar']);
+
+        $this->assertEquals(2, $collection->count());
+    }
+
+    /** @test */
+    public function can_create_collection_with_collect_helper()
+    {
+        $collection = collect(['foo', 'bar']);
+
+        $this->assertEquals(2, $collection->count());
+    }
+}

--- a/tests/Unit/CollectionsTest.php
+++ b/tests/Unit/CollectionsTest.php
@@ -3,8 +3,6 @@
 namespace Rareloop\Lumberjack\Test;
 
 use PHPUnit\Framework\TestCase;
-use Rareloop\Lumberjack\Config;
-use Tightenco\Collect\Support\Collection;
 
 class CollectionsTest extends TestCase
 {
@@ -29,5 +27,33 @@ class CollectionsTest extends TestCase
         $collection = collect(['foo', 'bar']);
 
         $this->assertEquals(2, $collection->count());
+    }
+
+    /** @test */
+    public function function_signatures_returning_collections_are_interchangeable()
+    {
+        $illuminate = new \Illuminate\Support\Collection(['foo', 'bar']);
+        $tighten = new \Tightenco\Collect\Support\Collection(['foo', 'bar']);
+
+        // Functions returning Illuminate namespace are happy with the current implementation
+        $this->assertEquals(2, CollectionsTester::returnAsIlluminate($illuminate)->count());
+        $this->assertEquals(2, CollectionsTester::returnAsIlluminate($tighten)->count());
+
+        // Functions returning the legacy Tightenco namespace are happy with the current implementation
+        $this->assertEquals(2, CollectionsTester::returnAsTighten($illuminate)->count());
+        $this->assertEquals(2, CollectionsTester::returnAsTighten($tighten)->count());
+    }
+}
+
+class CollectionsTester
+{
+    public static function returnAsTighten($collection): \Tightenco\Collect\Support\Collection
+    {
+        return $collection;
+    }
+
+    public static function returnAsIlluminate($collection): \Illuminate\Support\Collection
+    {
+        return $collection;
     }
 }

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -141,7 +141,8 @@ class HelpersTest extends TestCase
         $app = new Application;
         FacadeFactory::setContainer($app);
         $router = new Router;
-        $router->get('test/route', function () { })->name('test.route');
+        $router->get('test/route', function () {
+        })->name('test.route');
         $app->bind('router', $router);
 
         $url = Helpers::route('test.route');
@@ -155,7 +156,8 @@ class HelpersTest extends TestCase
         $app = new Application;
         FacadeFactory::setContainer($app);
         $router = new Router;
-        $router->get('test/{name}', function ($name) { })->name('test.route');
+        $router->get('test/{name}', function ($name) {
+        })->name('test.route');
         $app->bind('router', $router);
 
         $url = Helpers::route('test.route', [
@@ -351,6 +353,18 @@ class HelpersTest extends TestCase
         Helpers::logger('Example message', [
             'test' => 123,
         ]);
+    }
+
+    /** @test */
+    public function dump_function_exists()
+    {
+        $this->assertTrue(function_exists('dump'));
+    }
+
+    /** @test */
+    public function dd_function_exists()
+    {
+        $this->assertTrue(function_exists('dd'));
     }
 }
 


### PR DESCRIPTION
Migrate from `tightenco/collect` to `illuminate/collections`.

There will be a lot of user land code with reference to the Tighten namespace so add aliases that transparently use the Illuminate variants instead. Specifically we want to support the transparent use of `Collection` and `Arr`.

The Tighten package also brought in `symfony/var-dumper`, exposing `dd()` and `dump()` which Illuminate doesn't. So to minimise upgrade issues we now also require this package from `lumberjack-core`.