### PR TITLE
Gracefully handle encryption errors in session

### DIFF
--- a/src/Session/EncryptedStore.php
+++ b/src/Session/EncryptedStore.php
@@ -36,7 +36,7 @@ class EncryptedStore extends Store
             return $this->encrypter->decrypt($data);
         } catch (Exception $e) {
             $this->exceptionHandler->report($e);
-            return null;
+            return '';
         }
     }
 }

--- a/src/Session/EncryptedStore.php
+++ b/src/Session/EncryptedStore.php
@@ -12,8 +12,13 @@ class EncryptedStore extends Store
     protected $encrypter;
     protected $exceptionHandler;
 
-    public function __construct($name, SessionHandlerInterface $handler, Encrypter $encrypter, $id = null, HandlerInterface $exceptionHandler = null)
-    {
+    public function __construct(
+        $name,
+        SessionHandlerInterface $handler,
+        Encrypter $encrypter,
+        $id = null,
+        HandlerInterface $exceptionHandler = null
+    ) {
         $this->encrypter = $encrypter;
         $this->exceptionHandler = $exceptionHandler;
 

--- a/src/Session/EncryptedStore.php
+++ b/src/Session/EncryptedStore.php
@@ -2,16 +2,20 @@
 
 namespace Rareloop\Lumberjack\Session;
 
-use Rareloop\Lumberjack\Encrypter;
+use Exception;
 use SessionHandlerInterface;
+use Rareloop\Lumberjack\Encrypter;
+use Rareloop\Lumberjack\Exceptions\HandlerInterface;
 
 class EncryptedStore extends Store
 {
     protected $encrypter;
+    protected $exceptionHandler;
 
-    public function __construct($name, SessionHandlerInterface $handler, Encrypter $encrypter, $id = null)
+    public function __construct($name, SessionHandlerInterface $handler, Encrypter $encrypter, $id = null, HandlerInterface $exceptionHandler = null)
     {
         $this->encrypter = $encrypter;
+        $this->exceptionHandler = $exceptionHandler;
 
         parent::__construct($name, $handler, $id);
     }
@@ -23,6 +27,11 @@ class EncryptedStore extends Store
 
     protected function prepareForUnserialize($data)
     {
-        return $this->encrypter->decrypt($data);
+        try {
+            return $this->encrypter->decrypt($data);
+        } catch (Exception $e) {
+            $this->exceptionHandler->report($e);
+            return null;
+        }
     }
 }

--- a/tests/Unit/Session/EncryptedStoreTest.php
+++ b/tests/Unit/Session/EncryptedStoreTest.php
@@ -73,7 +73,7 @@ class EncryptedStoreTest extends TestCase
         $this->assertSame(null, $store->get('foo'));
     }
 
-    protected function unexpectedSessionData()
+    public function unexpectedSessionData()
     {
         return [
             [@serialize(['foo' => 'bar'])],

--- a/tests/Unit/Session/EncryptedStoreTest.php
+++ b/tests/Unit/Session/EncryptedStoreTest.php
@@ -73,7 +73,7 @@ class EncryptedStoreTest extends TestCase
         $this->assertSame(null, $store->get('foo'));
     }
 
-    private function unexpectedSessionData()
+    protected function unexpectedSessionData()
     {
         return [
             [@serialize(['foo' => 'bar'])],


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Enabling encrypted sessions on a site that already has unencrypted sessions would throw an exception. This makes the `EncryptedStore` handle unexpected data more gracefully.

Does this close any currently open issues?
------------------------------------------
No
