### PR TITLE
Support password protection

### DIFF
--- a/src/Http/Middleware/PasswordProtected.php
+++ b/src/Http/Middleware/PasswordProtected.php
@@ -5,9 +5,10 @@ namespace Rareloop\Lumberjack\Http\Middleware;
 use Timber\Timber;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
-use Laminas\Diactoros\Response\HtmlResponse;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Rareloop\Lumberjack\Exceptions\TwigTemplateNotFoundException;
+use Rareloop\Lumberjack\Http\Responses\TimberResponse;
 use Rareloop\Lumberjack\Post;
 
 class PasswordProtected implements MiddlewareInterface
@@ -32,15 +33,12 @@ class PasswordProtected implements MiddlewareInterface
         $context = Timber::context();
         $context['post'] = new Post();
 
-        $html = Timber::compile(
-            apply_filters('lumberjack/password_protect_template', 'single-password.twig'),
-            $context
-        );
+        $template = apply_filters('lumberjack/password_protect_template', 'single-password.twig');
 
-        if (!$html) {
+        try {
+            return new TimberResponse($template, $context);
+        } catch (TwigTemplateNotFoundException $e) {
             return null;
         }
-
-        return new HtmlResponse($html);
     }
 }

--- a/src/Http/Middleware/PasswordProtected.php
+++ b/src/Http/Middleware/PasswordProtected.php
@@ -32,7 +32,10 @@ class PasswordProtected implements MiddlewareInterface
         $context = Timber::context();
         $context['post'] = new Post();
 
-        $html = Timber::compile('single-password.twig', $context);
+        $html = Timber::compile(
+            apply_filters('lumberjack/password_protect_template', 'single-password.twig'),
+            $context
+        );
 
         if (!$html) {
             return null;

--- a/src/Http/Middleware/PasswordProtected.php
+++ b/src/Http/Middleware/PasswordProtected.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rareloop\Lumberjack\Http\Middleware;
+
+use Timber\Timber;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Rareloop\Lumberjack\Post;
+
+class PasswordProtected implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $passwordRequestResponse = $this->handlePasswordProtected();
+
+        if ($passwordRequestResponse) {
+            return $passwordRequestResponse;
+        }
+
+        return $handler->handle($request);
+    }
+
+    protected function handlePasswordProtected(): ?ResponseInterface
+    {
+        if (!post_password_required()) {
+            return null;
+        }
+
+        $context = Timber::context();
+        $context['post'] = new Post();
+
+        $html = Timber::compile('single-password.twig', $context);
+
+        if (!$html) {
+            return null;
+        }
+
+        return new HtmlResponse($html);
+    }
+}

--- a/src/Providers/WordPressControllersServiceProvider.php
+++ b/src/Providers/WordPressControllersServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use mindplay\middleman\Dispatcher;
 use Rareloop\Router\ResponseFactory;
 use Psr\Http\Message\RequestInterface;
+use Rareloop\Lumberjack\Http\Middleware\PasswordProtected;
 use Zend\Diactoros\ServerRequestFactory;
 use Rareloop\Router\ProvidesControllerMiddleware;
 
@@ -82,11 +83,11 @@ class WordPressControllersServiceProvider extends ServiceProvider
             })->all();
         }
 
-        $middlewares[] = function ($request) use ($controller, $methodName) {
+        $middlewares = [$this->app->get(PasswordProtected::class), ...$middlewares, function ($request) use ($controller, $methodName) {
             $invoker = new Invoker($this->app);
             $output = $invoker->setRequest($request)->call([$controller, $methodName]);
             return ResponseFactory::create($request, $output);
-        };
+        }];
 
         $dispatcher = $this->createDispatcher($middlewares);
         return $dispatcher->dispatch($request);

--- a/src/Providers/WordPressControllersServiceProvider.php
+++ b/src/Providers/WordPressControllersServiceProvider.php
@@ -83,11 +83,15 @@ class WordPressControllersServiceProvider extends ServiceProvider
             })->all();
         }
 
-        $middlewares = [$this->app->get(PasswordProtected::class), ...$middlewares, function ($request) use ($controller, $methodName) {
-            $invoker = new Invoker($this->app);
-            $output = $invoker->setRequest($request)->call([$controller, $methodName]);
-            return ResponseFactory::create($request, $output);
-        }];
+        $middlewares = [
+            $this->app->get(PasswordProtected::class),
+            ...$middlewares,
+            function ($request) use ($controller, $methodName) {
+                $invoker = new Invoker($this->app);
+                $output = $invoker->setRequest($request)->call([$controller, $methodName]);
+                return ResponseFactory::create($request, $output);
+            }
+        ];
 
         $dispatcher = $this->createDispatcher($middlewares);
         return $dispatcher->dispatch($request);

--- a/tests/Unit/Http/Middleware/PasswordProtectTest.php
+++ b/tests/Unit/Http/Middleware/PasswordProtectTest.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Rareloop\Lumberjack\Http\Middleware\PasswordProtected;
+use Rareloop\Lumberjack\Http\Responses\TimberResponse;
 use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
 
 /**
@@ -108,8 +109,10 @@ class PasswordProtectTest extends TestCase
         $handler->shouldReceive('handle')->never();
 
         $middleware = new PasswordProtected;
+        $response = $middleware->process($request, $handler);
 
-        $this->assertSame('testing123', $middleware->process($request, $handler)->getBody()->getContents());
+        $this->assertInstanceOf(TimberResponse::class, $response);
+        $this->assertSame('testing123', $response->getBody()->getContents());
         $this->assertTrue(Filters\applied('lumberjack/password_protect_template') > 0);
     }
 }

--- a/tests/Unit/Http/Middleware/PasswordProtectTest.php
+++ b/tests/Unit/Http/Middleware/PasswordProtectTest.php
@@ -5,7 +5,7 @@ namespace Rareloop\Lumberjack\Test\Http\Middleware;
 use Mockery;
 use Timber\Timber;
 use Brain\Monkey\Functions;
-use Laminas\Diactoros\Response\HtmlResponse;
+use Brain\Monkey\Filters;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -110,5 +110,6 @@ class PasswordProtectTest extends TestCase
         $middleware = new PasswordProtected;
 
         $this->assertSame('testing123', $middleware->process($request, $handler)->getBody()->getContents());
+        $this->assertTrue(Filters\applied('lumberjack/password_protect_template') > 0);
     }
 }

--- a/tests/Unit/Http/Middleware/PasswordProtectTest.php
+++ b/tests/Unit/Http/Middleware/PasswordProtectTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test\Http\Middleware;
+
+use Mockery;
+use Timber\Timber;
+use Brain\Monkey\Functions;
+use Laminas\Diactoros\Response\HtmlResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Rareloop\Lumberjack\Http\Middleware\PasswordProtected;
+use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class PasswordProtectTest extends TestCase
+{
+    use BrainMonkeyPHPUnitIntegration;
+
+    /** @test */
+    public function it_does_nothing_when_password_is_not_required()
+    {
+        $middleware = new PasswordProtected;
+
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
+        $request = Mockery::mock(ServerRequestInterface::class);
+        $response = Mockery::mock(ResponseInterface::class);
+        $handler = Mockery::mock(RequestHandlerInterface::class);
+
+        $handler->shouldReceive('handle')->once()->with($request)->andReturn($response);
+
+        $this->assertSame($response, $middleware->process($request, $handler));
+    }
+
+    /** @test */
+    public function it_does_nothing_when_the_password_twig_file_is_not_found()
+    {
+        $middleware = new PasswordProtected;
+
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(true);
+
+        Functions\expect('get_the_ID')
+            ->once()
+            ->andReturn(123);
+
+        Functions\expect('get_post')
+            ->once();
+
+        $timber = \Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('compile')
+            ->withArgs(function ($template) {
+                return $template === 'single-password.twig';
+            })
+            ->once()
+            ->andReturn(false);
+
+        $timber->shouldReceive('context')
+            ->once()
+            ->andReturn([]);
+
+        $request = Mockery::mock(ServerRequestInterface::class);
+        $response = Mockery::mock(ResponseInterface::class);
+        $handler = Mockery::mock(RequestHandlerInterface::class);
+
+        $handler->shouldReceive('handle')->once()->with($request)->andReturn($response);
+
+        $this->assertSame($response, $middleware->process($request, $handler));
+    }
+
+    /** @test */
+    public function it_renders_the_password_template_when_needed()
+    {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(true);
+
+        Functions\expect('get_the_ID')
+            ->once()
+            ->andReturn(123);
+
+        Functions\expect('get_post')
+            ->once();
+
+        $request = Mockery::mock(ServerRequestInterface::class);
+        $handler = Mockery::mock(RequestHandlerInterface::class);
+
+        $timber = \Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('compile')
+            ->withArgs(function ($template) {
+                return $template === 'single-password.twig';
+            })
+            ->once()
+            ->andReturn('testing123');
+
+        $timber->shouldReceive('context')
+            ->once()
+            ->andReturn([]);
+
+        $handler->shouldReceive('handle')->never();
+
+        $middleware = new PasswordProtected;
+
+        $this->assertSame('testing123', $middleware->process($request, $handler)->getBody()->getContents());
+    }
+}

--- a/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
+++ b/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace Rareloop\Lumberjack\Test\Providers;
 
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
+use Laminas\Diactoros\Response\HtmlResponse;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -24,6 +25,7 @@ use Rareloop\Router\Responsable;
 use Zend\Diactoros\Response\TextResponse;
 use Zend\Diactoros\ServerRequest;
 use \Mockery;
+use Rareloop\Lumberjack\Http\Middleware\PasswordProtected;
 
 class WordPressControllersServiceProviderTest extends TestCase
 {
@@ -156,6 +158,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_will_mark_request_handled_in_app_if_controller_does_exist()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
@@ -182,6 +188,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_returns_response_when_controller_does_exist()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
@@ -195,6 +205,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_returns_response_when_controller_returns_a_responsable()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
@@ -209,6 +223,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_resolves_constructor_params_from_container()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
@@ -222,6 +240,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_resolves_controller_method_params_from_container()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
@@ -235,6 +257,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_supports_middleware()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
         $controller = new TestControllerWithMiddleware;
         $controller->middleware(new AddHeaderMiddleware('X-Header', 'testing123'));
@@ -250,8 +276,32 @@ class WordPressControllersServiceProviderTest extends TestCase
     }
 
     /** @test */
+    public function handle_request_adds_password_protect_middleware()
+    {
+        $mock = Mockery::mock(PasswordProtected::class);
+        $mock->shouldReceive('process')->once()->andReturn(new HtmlResponse('password-protected'));
+
+        $app = new Application(__DIR__ . '/../');
+        $app->bind(PasswordProtected::class, $mock);
+
+        $controller = new TestControllerWithMiddleware;
+        $app->bind(TestControllerWithMiddleware::class, $controller);
+
+        $provider = new WordPressControllersServiceProvider($app);
+        $provider->boot($app);
+
+        $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
+
+        $this->assertSame('password-protected', $response->getBody()->getContents());
+    }
+
+    /** @test */
     public function handle_request_supports_middleware_applied_to_a_specific_method_using_only()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
         $controller = new TestControllerWithMiddleware;
         $controller->middleware(new AddHeaderMiddleware('X-Header', 'testing123'))->only('notHandle');
@@ -268,6 +318,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_supports_middleware_applied_to_a_specific_method_using_except()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         $app = new Application(__DIR__ . '/../');
         $controller = new TestControllerWithMiddleware;
         $controller->middleware(new AddHeaderMiddleware('X-Header', 'testing123'))->except('handle');
@@ -284,6 +338,10 @@ class WordPressControllersServiceProviderTest extends TestCase
     /** @test */
     public function handle_request_supports_middleware_aliases()
     {
+        Functions\expect('post_password_required')
+            ->once()
+            ->andReturn(false);
+
         Functions\when('get_bloginfo')->alias(function ($key) {
             if ($key === 'url') {
                 return 'http://example.com';


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This adds support for password protected pages. Following the [Timber guidelines](https://timber.github.io/docs/v1/guides/wp-integration/#password-protected-posts) this implements a middleware for pages/posts served via WordPress controllers that will render a special twig template if `post_password_required()` returns true.

The default template is `single-password.twig` but can be modified in the theme using the filter `lumberjack/password_protect_template`.

To ensure this isn't a breaking change if `Timber::compile()` returns `false` the middleware gracefully fallsback to the current behaviour, which is to ignore the password protect preference.
