### PR TITLE
Replace deprecated Symfony error handler

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Facades\Config;
-use Symfony\Component\Debug\ExceptionHandler as SymfonyExceptionHandler;
+use Symfony\Component\ErrorHandler\ErrorHandler as SymfonyExceptionHandler;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Zend\Diactoros\Response\HtmlResponse;
 


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you read the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the deprecation warning generated by the Symfony debug package.

Does this close any currently open issues?
------------------------------------------
Yes, https://github.com/Rareloop/lumberjack-core/issues/48


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No
