### PR TITLE
Remove PHP 7.3 from composer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A powerful MVC framework for the modern WordPress developer. Write better, more expressive and easier to maintain code",
     "license": "MIT",
     "require": {
-        "php": ">=7.3||>=8.0",
+        "php": ">=8.0",
         "php-di/php-di": "^6.4.0",
         "rareloop/router": "^6.0.2",
         "psr/container": "^1.1.2",


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you read the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes PHP 7.3 from the composer file

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…
