### PR TITLE
Migrate to Timber v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: [8.0, 8.1, 8.2]
+        php_version: [8.1, 8.2, 8.3]
         composer_flags: ['', '--prefer-lowest']
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A powerful MVC framework for the modern WordPress developer. Write better, more expressive and easier to maintain code",
     "license": "MIT",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "php-di/php-di": "^6.4.0",
         "rareloop/router": "^6.0.2",
         "psr/container": "^1.1.2",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "psr/http-message": "^1.1",
         "psr/http-server-middleware": "^1.0.2",
         "blast/facades": "^1.0",
-        "timber/timber": "^1.24.0",
+        "timber/timber": "^2.3.0",
         "monolog/monolog": "^2.9.1",
         "http-interop/response-sender": "^1.0",
         "symfony/debug": "^4.4.44",

--- a/src/Http/Middleware/PasswordProtected.php
+++ b/src/Http/Middleware/PasswordProtected.php
@@ -31,7 +31,7 @@ class PasswordProtected implements MiddlewareInterface
         }
 
         $context = Timber::context();
-        $context['post'] = new Post();
+        $context['post'] = Timber::get_post();
 
         $template = apply_filters('lumberjack/password_protect_template', 'single-password.twig');
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -8,7 +8,6 @@ use Spatie\Macroable\Macroable;
 use Timber\Post as TimberPost;
 use Timber\Timber;
 
-#[\AllowDynamicProperties]
 class Post extends TimberPost
 {
     use Macroable {
@@ -16,14 +15,14 @@ class Post extends TimberPost
         Macroable::__callStatic as __macroableCallStatic;
     }
 
-    public function __construct($id = false, $preventTimberInit = false)
+    public function __construct(mixed $wpPost = null, $preventTimberInit = false)
     {
         /**
          * There are occasions where we do not want the bootstrap the data. At the moment this is
          * designed to make Query Scopes possible
          */
         if (!$preventTimberInit) {
-            parent::__construct($id);
+            parent::__construct($wpPost);
         }
     }
 
@@ -102,7 +101,14 @@ class Post extends TimberPost
             throw new PostTypeRegistrationException('Config not set');
         }
 
+        add_filter('timber/post/classmap', [static::class, 'filterTimberPostClassMap']);
+
         register_post_type($postType, $config);
+    }
+
+    public static function filterTimberPostClassMap(array $classMap): array
+    {
+        return [...$classMap, static::getPostType() => static::class];
     }
 
     /**

--- a/src/Providers/TimberServiceProvider.php
+++ b/src/Providers/TimberServiceProvider.php
@@ -9,10 +9,7 @@ class TimberServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $timber = new Timber();
-
-        $this->app->bind('timber', $timber);
-        $this->app->bind(Timber::class, $timber);
+        Timber::init();
     }
 
     public function boot(Config $config)

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -159,16 +159,9 @@ class QueryBuilder implements QueryBuilderContract
         return $this;
     }
 
-    public function as($postClass): QueryBuilderContract
-    {
-        $this->postClass = $postClass;
-
-        return $this;
-    }
-
     public function get(): Collection
     {
-        $posts = Timber::get_posts($this->getParameters(), $this->postClass);
+        $posts = Timber::get_posts($this->getParameters());
 
         if (!is_array($posts)) {
             $posts = [];

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -163,11 +163,11 @@ class QueryBuilder implements QueryBuilderContract
     {
         $posts = Timber::get_posts($this->getParameters());
 
-        if (!is_array($posts)) {
-            $posts = [];
+        if ($posts === null) {
+            return collect([]);
         }
 
-        return collect($posts);
+        return collect($posts->to_array());
     }
 
     /**
@@ -181,13 +181,13 @@ class QueryBuilder implements QueryBuilderContract
             'limit' => 1,
         ]);
 
-        $posts = Timber::get_posts($params, $this->postClass);
+        $posts = Timber::get_posts($params);
 
-        if (!is_array($posts)) {
+        if ($posts === null || count($posts) === 0) {
             return null;
         }
 
-        return collect($posts)->first();
+        return collect($posts->to_array())->first();
     }
 
     public function clone(): QueryBuilderContract

--- a/src/ScopedQueryBuilder.php
+++ b/src/ScopedQueryBuilder.php
@@ -23,7 +23,6 @@ class ScopedQueryBuilder
         $this->queryBuilder = Helpers::app(QueryBuilderContract::class);
 
         $this->queryBuilder
-            ->as($postClass)
             ->wherePostType(call_user_func([$this->postClass, 'getPostType']));
     }
 
@@ -65,7 +64,7 @@ class ScopedQueryBuilder
      * @param  string  $name The method name
      * @return boolean
      */
-    protected function hasQueryBuilderMethod(string $name) : bool
+    protected function hasQueryBuilderMethod(string $name): bool
     {
         if (method_exists($this->queryBuilder, $name)) {
             return true;
@@ -81,10 +80,5 @@ class ScopedQueryBuilder
     public function wherePostType($postType)
     {
         throw new CannotRedeclarePostTypeOnQueryException;
-    }
-
-    public function as($postClass)
-    {
-        throw new CannotRedeclarePostClassOnQueryException;
     }
 }

--- a/tests/Unit/Http/Middleware/PasswordProtectTest.php
+++ b/tests/Unit/Http/Middleware/PasswordProtectTest.php
@@ -49,14 +49,8 @@ class PasswordProtectTest extends TestCase
             ->once()
             ->andReturn(true);
 
-        Functions\expect('get_the_ID')
-            ->once()
-            ->andReturn(123);
-
-        Functions\expect('get_post')
-            ->once();
-
         $timber = \Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('get_post')->once();
         $timber->shouldReceive('compile')
             ->withArgs(function ($template) {
                 return $template === 'single-password.twig';
@@ -84,17 +78,11 @@ class PasswordProtectTest extends TestCase
             ->once()
             ->andReturn(true);
 
-        Functions\expect('get_the_ID')
-            ->once()
-            ->andReturn(123);
-
-        Functions\expect('get_post')
-            ->once();
-
         $request = Mockery::mock(ServerRequestInterface::class);
         $handler = Mockery::mock(RequestHandlerInterface::class);
 
         $timber = \Mockery::mock('alias:' . Timber::class);
+        $timber->shouldReceive('get_post')->once();
         $timber->shouldReceive('compile')
             ->withArgs(function ($template) {
                 return $template === 'single-password.twig';

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -334,7 +334,6 @@ class QueryBuilderTest extends TestCase
                     'post_status' => 'publish',
                     'offset' => 10,
                 ]),
-                Post::class,
             ])
             ->once()
             ->andReturn($posts);
@@ -361,7 +360,6 @@ class QueryBuilderTest extends TestCase
                     'post_status' => 'publish',
                     'offset' => 10,
                 ]),
-                Post::class,
             ])
             ->once()
             ->andReturn(false);
@@ -388,7 +386,6 @@ class QueryBuilderTest extends TestCase
                     'post_status' => 'publish',
                     'offset' => 10,
                 ]),
-                Post::class,
             ])
             ->once()
             ->andReturn(null);
@@ -398,29 +395,6 @@ class QueryBuilderTest extends TestCase
 
         $this->assertInstanceOf(Collection::class, $returnedPosts);
         $this->assertSame(0, $returnedPosts->count());
-    }
-
-    /**
-     * @test
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
-    public function can_specify_the_class_type_to_return()
-    {
-        $timber = Mockery::mock('alias:' . Timber::class);
-        $timber
-            ->shouldReceive('get_posts')
-            ->withArgs([
-                Mockery::subset([
-                    'post_status' => 'publish',
-                    'offset' => 10,
-                ]),
-                PostWithCustomPostType::class,
-            ])
-            ->once();
-
-        $builder = new QueryBuilder();
-        $builder->whereStatus('publish')->offset(10)->as(PostWithCustomPostType::class)->get();
     }
 
     /**

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -384,6 +384,7 @@ class QueryBuilderTest extends TestCase
         $post = Mockery::mock(Post::class);
 
         $postQuery = Mockery::mock(PostQuery::class);
+        $postQuery->shouldReceive('count')->once()->andReturn(1);
         $postQuery->shouldReceive('to_array')->once()->andReturn([$post]);
 
         $timber = Mockery::mock('alias:' . Timber::class);

--- a/tests/Unit/ScopedQueryBuilderTest.php
+++ b/tests/Unit/ScopedQueryBuilderTest.php
@@ -2,16 +2,17 @@
 
 namespace Rareloop\Lumberjack\Test;
 
-use Illuminate\Support\Collection;
 use Mockery;
-use PHPUnit\Framework\TestCase;
-use Rareloop\Lumberjack\Application;
-use Rareloop\Lumberjack\Contracts\QueryBuilder as QueryBuilderContract;
-use Rareloop\Lumberjack\Post;
-use Rareloop\Lumberjack\QueryBuilder;
-use Rareloop\Lumberjack\ScopedQueryBuilder;
 use Throwable;
 use Timber\Timber;
+use Timber\PostQuery;
+use Rareloop\Lumberjack\Post;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
+use Rareloop\Lumberjack\Application;
+use Rareloop\Lumberjack\QueryBuilder;
+use Rareloop\Lumberjack\ScopedQueryBuilder;
+use Rareloop\Lumberjack\Contracts\QueryBuilder as QueryBuilderContract;
 
 class ScopedQueryBuilderTest extends TestCase
 {
@@ -55,7 +56,10 @@ class ScopedQueryBuilderTest extends TestCase
      */
     public function get_retrieves_list_of_posts()
     {
-        $posts = [new PostWithQueryScope(1, true), new PostWithQueryScope(2, true)];
+        // $posts = [new PostWithQueryScope(1, true), new PostWithQueryScope(2, true)];
+
+        $postQuery = Mockery::mock(PostQuery::class);
+        $postQuery->shouldReceive('to_array')->once()->andReturn([123, 'abc']);
 
         $timber = Mockery::mock('alias:' . Timber::class);
         $timber->shouldReceive('get_posts')->withArgs([
@@ -64,13 +68,13 @@ class ScopedQueryBuilderTest extends TestCase
                 'post_status' => 'publish',
                 'offset' => 10,
             ]),
-        ])->once()->andReturn($posts);
+        ])->once()->andReturn($postQuery);
 
         $builder = new ScopedQueryBuilder(PostWithQueryScope::class);
         $returnedPosts = $builder->whereStatus('publish')->offset(10)->get();
 
         $this->assertInstanceOf(Collection::class, $returnedPosts);
-        $this->assertSame($posts, $returnedPosts->toArray());
+        $this->assertSame([123, 'abc'], $returnedPosts->toArray());
     }
 
     /** @test */

--- a/tests/Unit/ScopedQueryBuilderTest.php
+++ b/tests/Unit/ScopedQueryBuilderTest.php
@@ -48,21 +48,12 @@ class ScopedQueryBuilderTest extends TestCase
         $builder->wherePostType('test_post_type');
     }
 
-    /** @test */
-    public function cannot_overwrite_post_class()
-    {
-        $this->expectException(\Rareloop\Lumberjack\Exceptions\CannotRedeclarePostClassOnQueryException::class);
-
-        $builder = new ScopedQueryBuilder(PostWithQueryScope::class);
-        $builder->as(Post::class);
-    }
-
     /**
      * @test
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function get_retrieves_list_of_posts_of_correct_type()
+    public function get_retrieves_list_of_posts()
     {
         $posts = [new PostWithQueryScope(1, true), new PostWithQueryScope(2, true)];
 
@@ -73,7 +64,6 @@ class ScopedQueryBuilderTest extends TestCase
                 'post_status' => 'publish',
                 'offset' => 10,
             ]),
-            PostWithQueryScope::class,
         ])->once()->andReturn($posts);
 
         $builder = new ScopedQueryBuilder(PostWithQueryScope::class);


### PR DESCRIPTION
Work in progress upgrade to Timber 2.

# Breaking changes specific to Lumberjack

- `Timber` object is no longer bound in the container and therefore not injectable
- `QueryBuilder`/`ScopedQueryBuilder`
    - `as()` removed - post objects are mapped to post types during constructor

# Things to document

Lumberjack `Post` and `Page` objects are not automatically mapped by the framework. This is to allow user land code to make this decision. The following code should be added to `AppServiceProvider` if you want to automatically map the Lumberjack objects:

```
add_filter('timber/post/classmap', fn($classmap) => [
        ...$classmap,
        'post' => Page::class,
        'page' => Page::class,
    ]);
```