### PR TITLE
Replace Symfony Exception Handler with Spatie Ignition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "mindplay/middleman": "^3.1.0",
         "psr/log": "^1.1.4",
         "laminas/laminas-zendframework-bridge": "^1.7",
-        "symfony/var-dumper": "^5.0||^6.3.6"
+        "symfony/var-dumper": "^5.0||^6.3.6",
+        "spatie/ignition": "^1.15"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.13",

--- a/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
+++ b/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
@@ -14,7 +14,6 @@ use Rareloop\Lumberjack\Exceptions\Handler;
 use Rareloop\Lumberjack\Exceptions\HandlerInterface;
 use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
 use Rareloop\Router\Responsable;
-use Symfony\Component\Debug\Exception\FatalErrorException;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\TextResponse;
 use Zend\Diactoros\ServerRequest;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Replaces the Symfony Exception Handler with the Spatie Ignition package - https://github.com/spatie/ignition. This provides a nicer debugging experience as the error page can show you the code in which the error was thrown, for example in this image from their Github repo:

![image](https://github.com/user-attachments/assets/ab37eacc-6a5d-4ef5-8aa2-1eb522a14124)


Does this close any currently open issues?
------------------------------------------

https://github.com/Rareloop/lumberjack-core/issues/32 - This issue requested we move to the Laravel exception handler (which at the time was Whoops), but Laravel have now moved to use Spatie Ignition.

https://github.com/Rareloop/lumberjack-core/issues/54 - This PR replaces the Symfony exception handler, so these deprecation errors will no longer appear.


Any other comments?
-------------------

Some of the work on https://github.com/Rareloop/lumberjack-core/pull/52 will no longer be required, as the error handler has been replaced
