### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,45 +3,44 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php_version: [8.1, 8.2, 8.3]
-        composer_flags: ['', '--prefer-lowest']
+    build-test:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php_version: [8.4]
+                composer_flags: ["", "--prefer-lowest"]
 
-    steps:
-    - uses: actions/checkout@v2
+        steps:
+            - uses: actions/checkout@v2
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php_version }}
-        extensions: xdebug
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php_version }}
+                  extensions: xdebug
 
-    - name: Install dependencies
-      uses: php-actions/composer@v5
-      with:
-        php_version: ${{ matrix.php_version }}
-        args: ${{ matrix.composer_flags }}
-        command: update
+            - name: Install dependencies
+              uses: php-actions/composer@v5
+              with:
+                  php_version: ${{ matrix.php_version }}
+                  args: ${{ matrix.composer_flags }}
+                  command: update
 
-    - name: Run tests
-      run: ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
-      env:
-          XDEBUG_MODE: coverage
+            - name: Run tests
+              run: ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
+              env:
+                  XDEBUG_MODE: coverage
 
-    - name: Run Codesniffer
-      run: vendor/bin/phpcs --standard=PSR2 ./src
+            - name: Run Codesniffer
+              run: vendor/bin/phpcs --standard=PSR2 ./src
 
-    # - name: Submit coverage to Coveralls
-    #   # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:
-    #   # https://github.com/coverallsapp/github-action/issues/15
-    #   env:
-    #     COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     COVERALLS_PARALLEL: true
-    #     COVERALLS_FLAG_NAME: ${{ github.job }}-PHP-${{ matrix.php_version }} ${{ matrix.composer_flags }}
-    #   run: |
-    #     composer global require php-coveralls/php-coveralls
-    #     ~/.composer/vendor/bin/php-coveralls -v
-
+        # - name: Submit coverage to Coveralls
+        #   # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:
+        #   # https://github.com/coverallsapp/github-action/issues/15
+        #   env:
+        #     COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #     COVERALLS_PARALLEL: true
+        #     COVERALLS_FLAG_NAME: ${{ github.job }}-PHP-${{ matrix.php_version }} ${{ matrix.composer_flags }}
+        #   run: |
+        #     composer global require php-coveralls/php-coveralls
+        #     ~/.composer/vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -3,26 +3,24 @@
     "description": "A powerful MVC framework for the modern WordPress developer. Write better, more expressive and easier to maintain code",
     "license": "MIT",
     "require": {
-        "php": ">=8.1",
-        "php-di/php-di": "^6.4.0",
-        "rareloop/router": "^6.0.2",
-        "psr/container": "^1.1.2",
-        "psr/http-message": "^1.1",
+        "php": ">=8.4",
+        "php-di/php-di": "^7",
+        "rareloop/router": "dev-feature/upgrade-dependencies as 6.0.2",
+        "psr/container": "^2",
+        "psr/http-message": "^2",
         "psr/http-server-middleware": "^1.0.2",
         "blast/facades": "^1.0",
         "timber/timber": "^2.3.0",
-        "monolog/monolog": "^2.9.1",
-        "http-interop/response-sender": "^1.0",
+        "monolog/monolog": "^3.9",
         "symfony/debug": "^4.4.44",
-        "illuminate/collections": "^8.53.1||^9.52.16",
+        "illuminate/collections": "^12",
         "statamic/stringy": "^3.1.3",
-        "laminas/laminas-diactoros": "^2.25.2",
-        "rareloop/psr7-server-request-extension": "^2.1.0",
+        "laminas/laminas-diactoros": "^3.6.0",
+        "rareloop/psr7-server-request-extension": "dev-master as 3.0",
         "mmeyer2k/dcrypt": "^8.3.1",
         "spatie/macroable": "^1.0.1",
-        "mindplay/middleman": "^3.1.0",
-        "psr/log": "^1.1.4",
-        "laminas/laminas-zendframework-bridge": "^1.7",
+        "mindplay/middleman": "^4.0.4",
+        "psr/log": "^2.0.0",
         "symfony/var-dumper": "^5.0||^6.3.6"
     },
     "require-dev": {
@@ -31,9 +29,10 @@
         "mockery/mockery": "^1.6.6",
         "brain/monkey": "^2.6.1",
         "squizlabs/php_codesniffer": "^3.7.2",
-        "php-mock/php-mock": "^2.4.1",
+        "php-mock/php-mock": "^2.6.2",
         "mikey179/vfsstream": "1.6.11",
-        "dms/phpunit-arraysubset-asserts": "^0.3.1"
+        "dms/phpunit-arraysubset-asserts": "^0.3.1",
+        "rector/rector": "^2.1"
     },
     "autoload": {
         "psr-4": {
@@ -49,5 +48,15 @@
         "allow-plugins": {
             "composer/installers": true
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/rareloop/router"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/tommitchelmore/psr7-server-request-extension"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "psr/container": "^2",
         "psr/http-message": "^2",
         "psr/http-server-middleware": "^1.0.2",
-        "blast/facades": "^1.0",
         "timber/timber": "^2.3.0",
         "monolog/monolog": "^3.9",
         "symfony/debug": "^4.4.44",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    // uncomment to reach your current PHP version
+    ->withPhpSets(php84: true);
+    // ->withTypeCoverageLevel(0)
+    // ->withDeadCodeLevel(0)
+    // ->withCodeQualityLevel(0);

--- a/src/Application.php
+++ b/src/Application.php
@@ -3,12 +3,11 @@
 namespace Rareloop\Lumberjack;
 
 use Closure;
-use DI\ContainerBuilder;
+use DI\Container;
 use Illuminate\Support\Collection;
 use Interop\Container\ContainerInterface as InteropContainerInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
-use Rareloop\Router\Invoker;
 use function Http\Response\send;
 
 class Application implements ContainerInterface, InteropContainerInterface
@@ -24,7 +23,7 @@ class Application implements ContainerInterface, InteropContainerInterface
 
     public function __construct($basePath = false)
     {
-        $this->container = ContainerBuilder::buildDevContainer();
+        $this->container = new Container();
 
         $this->bind(Application::class, $this);
 
@@ -232,7 +231,7 @@ class Application implements ContainerInterface, InteropContainerInterface
      *
      * @return boolean
      */
-    public function hasRequestBeenHandled() : bool
+    public function hasRequestBeenHandled(): bool
     {
         return $this->requestHandled;
     }
@@ -263,10 +262,10 @@ class Application implements ContainerInterface, InteropContainerInterface
                 if ($this->has('__wp-controller-miss-template') && $this->has('__wp-controller-miss-controller')) {
                     wp_die(
                         'Loaded template <code>' .
-                        $this->get('__wp-controller-miss-template') .
-                        '</code> but couldn\'t find class <code>' .
-                        $this->get('__wp-controller-miss-controller') .
-                        '</code>'
+                            $this->get('__wp-controller-miss-template') .
+                            '</code> but couldn\'t find class <code>' .
+                            $this->get('__wp-controller-miss-controller') .
+                            '</code>'
                     );
                 }
             }
@@ -288,7 +287,7 @@ class Application implements ContainerInterface, InteropContainerInterface
         die();
     }
 
-    protected function removeSentHeadersAndMoveIntoResponse(ResponseInterface $response) : ResponseInterface
+    protected function removeSentHeadersAndMoveIntoResponse(ResponseInterface $response): ResponseInterface
     {
         // 1. Format the previously sent headers into an array of [key, value]
         // 2. Remove all headers from the output that we find

--- a/src/Application.php
+++ b/src/Application.php
@@ -5,12 +5,11 @@ namespace Rareloop\Lumberjack;
 use Closure;
 use DI\Container;
 use Illuminate\Support\Collection;
-use Interop\Container\ContainerInterface as InteropContainerInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use function Http\Response\send;
 
-class Application implements ContainerInterface, InteropContainerInterface
+class Application implements ContainerInterface
 {
     private $container;
     private $loadedProviders = [];
@@ -151,7 +150,7 @@ class Application implements ContainerInterface, InteropContainerInterface
      *
      * @return bool
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         return $this->container->has($id);
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -182,11 +182,9 @@ class Application implements ContainerInterface, InteropContainerInterface
 
     public function getProvider($provider)
     {
-        $providerClass = is_string($provider) ? $provider : get_class($provider);
+        $providerClass = is_string($provider) ? $provider : $provider::class;
 
-        return (new Collection($this->loadedProviders))->first(function ($provider) use ($providerClass) {
-            return get_class($provider) === $providerClass;
-        });
+        return new Collection($this->loadedProviders)->first(fn($provider) => $provider::class === $providerClass);
     }
 
     public function getLoadedProviders()
@@ -275,7 +273,7 @@ class Application implements ContainerInterface, InteropContainerInterface
         });
     }
 
-    public function shutdown(ResponseInterface $response = null)
+    public function shutdown(?ResponseInterface $response = null)
     {
         if ($response) {
             global $wp;
@@ -300,16 +298,12 @@ class Application implements ContainerInterface, InteropContainerInterface
             header_remove($parts[0]);
 
             return $parts;
-        })->filter(function ($header) {
-            return !in_array(strtolower($header[0]), ['content-type']);
-        });
+        })->filter(fn($header) => !in_array(strtolower((string) $header[0]), ['content-type']));
 
         // Add the previously sent headers into the response
         // Note: You can't mutate a response so we need to use the reduce to end up with a response
         // object with all the correct headers
-        $responseToSend = collect($headersToAdd)->reduce(function ($newResponse, $header) {
-            return $newResponse->withAddedHeader($header[0], $header[1]);
-        }, $response);
+        $responseToSend = collect($headersToAdd)->reduce(fn($newResponse, $header) => $newResponse->withAddedHeader($header[0], $header[1]), $response);
 
         return $responseToSend;
     }

--- a/src/Bootstrappers/RegisterExceptionHandler.php
+++ b/src/Bootstrappers/RegisterExceptionHandler.php
@@ -10,7 +10,7 @@ use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Exceptions\HandlerInterface;
 use Rareloop\Router\Responsable;
 use Symfony\Component\Debug\Exception\FatalErrorException;
-use Zend\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFactory;
 use function Http\Response\send;
 
 /**

--- a/src/Bootstrappers/RegisterExceptionHandler.php
+++ b/src/Bootstrappers/RegisterExceptionHandler.php
@@ -34,8 +34,8 @@ class RegisterExceptionHandler
         }
 
         error_reporting(-1);
-        set_error_handler([$this, 'handleError']);
-        set_exception_handler([$this, 'handleException']);
+        set_error_handler($this->handleError(...));
+        set_exception_handler($this->handleException(...));
         register_shutdown_function([$this, 'handleShutdown']);
     }
 
@@ -50,7 +50,7 @@ class RegisterExceptionHandler
 
         try {
             $request = $this->app->get('request');
-        } catch (NotFoundException $notFoundException) {
+        } catch (NotFoundException) {
             $request = ServerRequestFactory::fromGlobals(
                 $_SERVER,
                 $_GET,

--- a/src/Bootstrappers/RegisterFacades.php
+++ b/src/Bootstrappers/RegisterFacades.php
@@ -2,13 +2,13 @@
 
 namespace Rareloop\Lumberjack\Bootstrappers;
 
-use Blast\Facades\FacadeFactory;
 use Rareloop\Lumberjack\Application;
+use Rareloop\Lumberjack\FacadeManager;
 
 class RegisterFacades
 {
     public function bootstrap(Application $app)
     {
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -9,7 +9,7 @@ class Config
 {
     private $data = [];
 
-    public function __construct(string $path = null)
+    public function __construct(?string $path = null)
     {
         if ($path) {
             $this->load($path);

--- a/src/Contracts/QueryBuilder.php
+++ b/src/Contracts/QueryBuilder.php
@@ -16,7 +16,7 @@ interface QueryBuilder
 
     public function orderBy($orderBy, string $order = QueryBuilder::ASC): QueryBuilder;
 
-    public function orderByMeta($metaKey, string $order = QueryBuilder::ASC, string $type = null): QueryBuilder;
+    public function orderByMeta($metaKey, string $order = QueryBuilder::ASC, ?string $type = null): QueryBuilder;
 
     public function whereIdIn(array $ids): QueryBuilder;
 

--- a/src/Encrypter.php
+++ b/src/Encrypter.php
@@ -7,11 +7,8 @@ use Rareloop\Lumberjack\Contracts\Encrypter as EncrypterContract;
 
 class Encrypter implements EncrypterContract
 {
-    protected $key;
-
-    public function __construct($key)
+    public function __construct(protected $key)
     {
-        $this->key = $key;
     }
 
     public function encrypt($data)

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -9,7 +9,7 @@ use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Facades\Config;
 use Symfony\Component\Debug\ExceptionHandler as SymfonyExceptionHandler;
 use Symfony\Component\Debug\Exception\FlattenException;
-use Zend\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\HtmlResponse;
 
 class Handler implements HandlerInterface
 {
@@ -34,7 +34,7 @@ class Handler implements HandlerInterface
         }
     }
 
-    public function render(ServerRequestInterface $request, Exception $e) : ResponseInterface
+    public function render(ServerRequestInterface $request, Exception $e): ResponseInterface
     {
         $e = FlattenException::create($e);
 

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -45,6 +45,6 @@ class Handler implements HandlerInterface
 
     protected function shouldNotReport(Exception $e)
     {
-        return in_array(get_class($e), $this->dontReport);
+        return in_array($e::class, $this->dontReport);
     }
 }

--- a/src/FacadeManager.php
+++ b/src/FacadeManager.php
@@ -20,6 +20,6 @@ class FacadeManager
 
     public static function create(string $accessor, $name, array $arguments = [])
     {
-        return call_user_func([static::$container->get($accessor), $name], $arguments);
+        return call_user_func([static::$container->get($accessor), $name], ...$arguments);
     }
 }

--- a/src/FacadeManager.php
+++ b/src/FacadeManager.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rareloop\Lumberjack;
+
+use Psr\Container\ContainerInterface;
+
+class FacadeManager
+{
+    protected static ?ContainerInterface $container = null;
+
+    public static function getContainer()
+    {
+        return self::$container;
+    }
+
+    public static function setContainer(ContainerInterface $container)
+    {
+        self::$container = $container;
+    }
+
+    public static function create(string $accessor, $name, array $arguments = [])
+    {
+        return call_user_func([static::$container->get($accessor), $name], $arguments);
+    }
+}

--- a/src/Facades/Config.php
+++ b/src/Facades/Config.php
@@ -6,6 +6,7 @@ use Blast\Facades\AbstractFacade;
 
 class Config extends AbstractFacade
 {
+    #[\Override]
     protected static function accessor()
     {
         return 'config';

--- a/src/Facades/Config.php
+++ b/src/Facades/Config.php
@@ -2,11 +2,8 @@
 
 namespace Rareloop\Lumberjack\Facades;
 
-use Blast\Facades\AbstractFacade;
-
-class Config extends AbstractFacade
+class Config extends Facade
 {
-    #[\Override]
     protected static function accessor()
     {
         return 'config';

--- a/src/Facades/Facade.php
+++ b/src/Facades/Facade.php
@@ -17,5 +17,5 @@ abstract class Facade
         return FacadeManager::getContainer()->get(static::accessor());
     }
 
-    abstract public static function accessor(): string;
+    abstract protected static function accessor();
 }

--- a/src/Facades/Facade.php
+++ b/src/Facades/Facade.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rareloop\Lumberjack\Facades;
+
+use Mockery;
+use Rareloop\Lumberjack\FacadeManager;
+
+abstract class Facade
+{
+    public static function __callStatic($name, array $arguments = [])
+    {
+        return FacadeManager::create(static::accessor(), $name, $arguments);
+    }
+
+    public static function __instance()
+    {
+        return FacadeManager::getContainer()->get(static::accessor());
+    }
+
+    abstract public static function accessor(): string;
+}

--- a/src/Facades/Log.php
+++ b/src/Facades/Log.php
@@ -2,11 +2,8 @@
 
 namespace Rareloop\Lumberjack\Facades;
 
-use Blast\Facades\AbstractFacade;
-
-class Log extends AbstractFacade
+class Log extends Facade
 {
-    #[\Override]
     protected static function accessor()
     {
         return 'logger';

--- a/src/Facades/Log.php
+++ b/src/Facades/Log.php
@@ -6,6 +6,7 @@ use Blast\Facades\AbstractFacade;
 
 class Log extends AbstractFacade
 {
+    #[\Override]
     protected static function accessor()
     {
         return 'logger';

--- a/src/Facades/MiddlewareAliases.php
+++ b/src/Facades/MiddlewareAliases.php
@@ -6,6 +6,7 @@ use Blast\Facades\AbstractFacade;
 
 class MiddlewareAliases extends AbstractFacade
 {
+    #[\Override]
     protected static function accessor()
     {
         return 'middleware-alias-store';

--- a/src/Facades/MiddlewareAliases.php
+++ b/src/Facades/MiddlewareAliases.php
@@ -2,11 +2,9 @@
 
 namespace Rareloop\Lumberjack\Facades;
 
-use Blast\Facades\AbstractFacade;
 
-class MiddlewareAliases extends AbstractFacade
+class MiddlewareAliases extends Facade
 {
-    #[\Override]
     protected static function accessor()
     {
         return 'middleware-alias-store';

--- a/src/Facades/Router.php
+++ b/src/Facades/Router.php
@@ -6,6 +6,7 @@ use Blast\Facades\AbstractFacade;
 
 class Router extends AbstractFacade
 {
+    #[\Override]
     protected static function accessor()
     {
         return 'router';

--- a/src/Facades/Router.php
+++ b/src/Facades/Router.php
@@ -2,11 +2,8 @@
 
 namespace Rareloop\Lumberjack\Facades;
 
-use Blast\Facades\AbstractFacade;
-
-class Router extends AbstractFacade
+class Router extends Facade
 {
-    #[\Override]
     protected static function accessor()
     {
         return 'router';

--- a/src/Facades/Session.php
+++ b/src/Facades/Session.php
@@ -6,6 +6,7 @@ use Blast\Facades\AbstractFacade;
 
 class Session extends AbstractFacade
 {
+    #[\Override]
     protected static function accessor()
     {
         return 'session';

--- a/src/Facades/Session.php
+++ b/src/Facades/Session.php
@@ -4,9 +4,8 @@ namespace Rareloop\Lumberjack\Facades;
 
 use Blast\Facades\AbstractFacade;
 
-class Session extends AbstractFacade
+class Session extends Facade
 {
-    #[\Override]
     protected static function accessor()
     {
         return 'session';

--- a/src/Facades/Session.php
+++ b/src/Facades/Session.php
@@ -2,8 +2,6 @@
 
 namespace Rareloop\Lumberjack\Facades;
 
-use Blast\Facades\AbstractFacade;
-
 class Session extends Facade
 {
     protected static function accessor()

--- a/src/Http/Lumberjack.php
+++ b/src/Http/Lumberjack.php
@@ -13,8 +13,6 @@ use Rareloop\Lumberjack\Bootstrappers\RegisterRequestHandler;
 
 class Lumberjack
 {
-    private $app;
-
     protected $bootstrappers = [
         LoadConfiguration::class,
         RegisterExceptionHandler::class,
@@ -25,9 +23,8 @@ class Lumberjack
         RegisterRequestHandler::class,
     ];
 
-    public function __construct(Application $app)
+    public function __construct(private readonly Application $app)
     {
-        $this->app = $app;
     }
 
     public function bootstrap()

--- a/src/Http/Middleware/PasswordProtected.php
+++ b/src/Http/Middleware/PasswordProtected.php
@@ -37,7 +37,7 @@ class PasswordProtected implements MiddlewareInterface
 
         try {
             return new TimberResponse($template, $context);
-        } catch (TwigTemplateNotFoundException $e) {
+        } catch (TwigTemplateNotFoundException) {
             return null;
         }
     }

--- a/src/Http/MiddlewareAliasStore.php
+++ b/src/Http/MiddlewareAliasStore.php
@@ -17,7 +17,7 @@ class MiddlewareAliasStore implements MiddlewareAliases
 
     public function get(string $name)
     {
-        list($name, $params) = $this->parseName($name);
+        [$name, $params] = $this->parseName($name);
 
         $middleware = $this->aliases[$name];
 
@@ -34,7 +34,7 @@ class MiddlewareAliasStore implements MiddlewareAliases
 
     protected function parseName($name) : array
     {
-        list($name, $params) = array_pad(explode(':', $name), 2, '');
+        [$name, $params] = array_pad(explode(':', (string) $name), 2, '');
 
         $params = explode(',', $params);
 
@@ -43,7 +43,7 @@ class MiddlewareAliasStore implements MiddlewareAliases
 
     public function has(string $name) : bool
     {
-        list($name, $params) = $this->parseName($name);
+        [$name, $params] = $this->parseName($name);
 
         return isset($this->aliases[$name]);
     }

--- a/src/Http/Responses/RedirectResponse.php
+++ b/src/Http/Responses/RedirectResponse.php
@@ -3,7 +3,7 @@
 namespace Rareloop\Lumberjack\Http\Responses;
 
 use Rareloop\Lumberjack\Helpers;
-use Zend\Diactoros\Response\RedirectResponse as DiactorosRedirectResponse;
+use Laminas\Diactoros\Response\RedirectResponse as DiactorosRedirectResponse;
 
 class RedirectResponse extends DiactorosRedirectResponse
 {

--- a/src/Http/Responses/TimberResponse.php
+++ b/src/Http/Responses/TimberResponse.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Support\Arrayable as CollectionArrayable;
 use Rareloop\Lumberjack\Contracts\Arrayable;
 use Rareloop\Lumberjack\Exceptions\TwigTemplateNotFoundException;
 use Timber\Timber;
-use Zend\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\HtmlResponse;
 
 class TimberResponse extends HtmlResponse
 {
@@ -21,7 +21,7 @@ class TimberResponse extends HtmlResponse
         parent::__construct($template, $status, $headers);
     }
 
-    private function flattenContextToArrays(array $context) : array
+    private function flattenContextToArrays(array $context): array
     {
         // Recursively walk the array, when we find something that implements the Arrayable interface
         // flatten it to an array. Because we're passing by reference by updating what the value of

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -17,6 +17,7 @@ class Router extends RareRouter
      * @param  callable|string $callback
      * @return \Rareloop\Router\Route
      */
+    #[\Override]
     public function map(array $verbs, string $uri, $callback): Route
     {
         if ($this->isControllerString($callback)) {
@@ -34,7 +35,7 @@ class Router extends RareRouter
      */
     private function isControllerString($callback) : bool
     {
-        return is_string($callback) && strpos($callback, '@') !== false;
+        return is_string($callback) && str_contains($callback, '@');
     }
 
     /**
@@ -45,7 +46,7 @@ class Router extends RareRouter
      */
     private function normaliseCallbackString(string $callback) : string
     {
-        @list($controller, $method) = explode('@', $callback);
+        @[$controller, $method] = explode('@', $callback);
 
         if (class_exists($this->defaultControllerNamespace . $controller)) {
             return $this->defaultControllerNamespace . $callback;

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -5,7 +5,7 @@ namespace Rareloop\Lumberjack\Http;
 use Psr\Http\Message\ServerRequestInterface;
 use Rareloop\Psr7ServerRequestExtension\InteractsWithInput;
 use Rareloop\Psr7ServerRequestExtension\InteractsWithUri;
-use Zend\Diactoros\ServerRequest as DiactorosServerRequest;
+use Laminas\Diactoros\ServerRequest as DiactorosServerRequest;
 
 class ServerRequest extends DiactorosServerRequest
 {
@@ -34,7 +34,7 @@ class ServerRequest extends DiactorosServerRequest
         );
     }
 
-    public function ajax() : bool
+    public function ajax(): bool
     {
         if (!$this->hasHeader('X-Requested-With')) {
             return false;
@@ -43,7 +43,7 @@ class ServerRequest extends DiactorosServerRequest
         return 'XMLHttpRequest' === $this->getHeader('X-Requested-With')[0];
     }
 
-    public function getMethod() : string
+    public function getMethod(): string
     {
         return strtoupper(parent::getMethod());
     }

--- a/src/Page.php
+++ b/src/Page.php
@@ -11,6 +11,7 @@ class Page extends Post
      *
      * @return string
      */
+    #[\Override]
     public static function getPostType()
     {
         return 'page';

--- a/src/Post.php
+++ b/src/Post.php
@@ -26,6 +26,7 @@ class Post extends TimberPost
         }
     }
 
+    #[\Override]
     public function __call($name, $arguments)
     {
         if (static::hasMacro($name)) {
@@ -46,7 +47,7 @@ class Post extends TimberPost
             return call_user_func_array([$builder, $name], $arguments);
         }
 
-        trigger_error('Call to undefined method ' . __CLASS__ . '::' . $name . '()', E_USER_ERROR);
+        trigger_error('Call to undefined method ' . self::class . '::' . $name . '()', E_USER_ERROR);
     }
 
     /**
@@ -101,7 +102,7 @@ class Post extends TimberPost
             throw new PostTypeRegistrationException('Config not set');
         }
 
-        add_filter('timber/post/classmap', [static::class, 'filterTimberPostClassMap']);
+        add_filter('timber/post/classmap', static::filterTimberPostClassMap(...));
 
         register_post_type($postType, $config);
     }
@@ -119,7 +120,7 @@ class Post extends TimberPost
      */
     public static function all($perPage = -1, $orderby = 'menu_order', $order = 'ASC')
     {
-        $order = strtoupper($order);
+        $order = strtoupper((string) $order);
 
         $args = [
             'posts_per_page' => $perPage,
@@ -161,6 +162,6 @@ class Post extends TimberPost
      */
     private static function posts($args = null)
     {
-        return collect(Timber::get_posts($args, get_called_class()));
+        return collect(Timber::get_posts($args, static::class));
     }
 }

--- a/src/Providers/RouterServiceProvider.php
+++ b/src/Providers/RouterServiceProvider.php
@@ -9,7 +9,7 @@ use Rareloop\Lumberjack\Http\MiddlewareResolver;
 use Rareloop\Lumberjack\Http\Router;
 use Rareloop\Lumberjack\Http\ServerRequest;
 use Rareloop\Router\MiddlewareResolver as MiddlewareResolverInterface;
-use Zend\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFactory;
 
 class RouterServiceProvider extends ServiceProvider
 {

--- a/src/Providers/SessionServiceProvider.php
+++ b/src/Providers/SessionServiceProvider.php
@@ -43,12 +43,8 @@ class SessionServiceProvider extends ServiceProvider
 
                 setcookie(
                     $this->session->getName(),
-                    $this->session->getId(),
-                    time() + ($cookieOptions['lifetime'] * 60),
-                    $cookieOptions['path'],
-                    $cookieOptions['domain'],
-                    $cookieOptions['secure'],
-                    $cookieOptions['httpOnly']
+                    (string) $this->session->getId(),
+                    ['expires' => time() + ($cookieOptions['lifetime'] * 60), 'path' => $cookieOptions['path'], 'domain' => $cookieOptions['domain'], 'secure' => $cookieOptions['secure'], 'httponly' => $cookieOptions['httpOnly']]
                 );
 
                 $cookieSet = true;

--- a/src/Providers/WordPressControllersServiceProvider.php
+++ b/src/Providers/WordPressControllersServiceProvider.php
@@ -9,7 +9,7 @@ use mindplay\middleman\Dispatcher;
 use Rareloop\Router\ResponseFactory;
 use Psr\Http\Message\RequestInterface;
 use Rareloop\Lumberjack\Http\Middleware\PasswordProtected;
-use Zend\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFactory;
 use Rareloop\Router\ProvidesControllerMiddleware;
 
 class WordPressControllersServiceProvider extends ServiceProvider

--- a/src/Providers/WordPressControllersServiceProvider.php
+++ b/src/Providers/WordPressControllersServiceProvider.php
@@ -16,7 +16,7 @@ class WordPressControllersServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        add_filter('template_include', [$this, 'handleTemplateInclude']);
+        add_filter('template_include', $this->handleTemplateInclude(...));
     }
 
     public function handleTemplateInclude($template)
@@ -38,14 +38,14 @@ class WordPressControllersServiceProvider extends ServiceProvider
         if ($response) {
             $this->app->shutdown($response);
         } else {
-            $this->app->bind('__wp-controller-miss-template', basename($template));
+            $this->app->bind('__wp-controller-miss-template', basename((string) $template));
             $this->app->bind('__wp-controller-miss-controller', $controller);
         }
     }
 
     public function getControllerClassFromTemplate($template)
     {
-        $controllerName = Stringy::create(basename($template, '.php'))->upperCamelize() . 'Controller';
+        $controllerName = Stringy::create(basename((string) $template, '.php'))->upperCamelize() . 'Controller';
 
         // Classes can't start with a number so we have to special case the behaviour here
         if ($controllerName === '404Controller') {
@@ -76,11 +76,7 @@ class WordPressControllersServiceProvider extends ServiceProvider
         if ($controller instanceof ProvidesControllerMiddleware) {
             $controllerMiddleware = new Collection($controller->getControllerMiddleware());
 
-            $middlewares = $controllerMiddleware->reject(function ($cm) use ($methodName) {
-                return $cm->excludedForMethod($methodName);
-            })->map(function ($cm) {
-                return $cm->middleware();
-            })->all();
+            $middlewares = $controllerMiddleware->reject(fn($cm) => $cm->excludedForMethod($methodName))->map(fn($cm) => $cm->middleware())->all();
         }
 
         $middlewares = [
@@ -102,9 +98,7 @@ class WordPressControllersServiceProvider extends ServiceProvider
         $resolver = null;
 
         if ($this->app->has('middleware-resolver')) {
-            $resolver = function ($name) {
-                return $this->app->get('middleware-resolver')->resolve($name);
-            };
+            $resolver = (fn($name) => $this->app->get('middleware-resolver')->resolve($name));
         }
 
         return new Dispatcher($middlewares, $resolver);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -82,7 +82,7 @@ class QueryBuilder implements QueryBuilderContract
         return $this;
     }
 
-    public function orderByMeta($metaKey, string $order = QueryBuilder::ASC, string $type = null): QueryBuilderContract
+    public function orderByMeta($metaKey, string $order = QueryBuilder::ASC, ?string $type = null): QueryBuilderContract
     {
         $order = strtoupper($order);
 
@@ -122,7 +122,7 @@ class QueryBuilder implements QueryBuilderContract
 
     protected function initialiseMetaQuery()
     {
-        $this->params['meta_query'] = $this->params['meta_query'] ?? [];
+        $this->params['meta_query'] ??= [];
     }
 
     public function whereMeta($key, $value, $compare = '=', $type = null): QueryBuilderContract

--- a/src/ScopedQueryBuilder.php
+++ b/src/ScopedQueryBuilder.php
@@ -12,14 +12,10 @@ use ReflectionMethod;
 
 class ScopedQueryBuilder
 {
-    protected $postClass;
-
     protected $queryBuilder;
 
-    public function __construct($postClass)
+    public function __construct(protected $postClass)
     {
-        $this->postClass = $postClass;
-
         $this->queryBuilder = Helpers::app(QueryBuilderContract::class);
 
         $this->queryBuilder
@@ -38,12 +34,10 @@ class ScopedQueryBuilder
         }
 
         // See if this is a scope function that needs calling
-        $scopeFunctionName = 'scope' . ucfirst($name);
+        $scopeFunctionName = 'scope' . ucfirst((string) $name);
 
         $reflection = new ReflectionClass($this->postClass);
-        $publicMethods = collect($reflection->getMethods(ReflectionMethod::IS_PUBLIC))->map(function ($method) {
-            return $method->getName();
-        })->toArray();
+        $publicMethods = collect($reflection->getMethods(ReflectionMethod::IS_PUBLIC))->map(fn($method) => $method->getName())->toArray();
 
         if (!in_array($scopeFunctionName, $publicMethods)) {
             trigger_error(
@@ -54,7 +48,7 @@ class ScopedQueryBuilder
 
         array_unshift($arguments, $this);
 
-        return (new $this->postClass(false, true))->{$scopeFunctionName}(...$arguments);
+        return new $this->postClass(false, true)->{$scopeFunctionName}(...$arguments);
     }
 
     /**
@@ -77,7 +71,7 @@ class ScopedQueryBuilder
         return false;
     }
 
-    public function wherePostType($postType)
+    public function wherePostType($postType): never
     {
         throw new CannotRedeclarePostTypeOnQueryException;
     }

--- a/src/Session/EncryptedStore.php
+++ b/src/Session/EncryptedStore.php
@@ -17,7 +17,7 @@ class EncryptedStore extends Store
         SessionHandlerInterface $handler,
         Encrypter $encrypter,
         $id = null,
-        HandlerInterface $exceptionHandler = null
+        ?HandlerInterface $exceptionHandler = null
     ) {
         $this->encrypter = $encrypter;
         $this->exceptionHandler = $exceptionHandler;
@@ -25,11 +25,13 @@ class EncryptedStore extends Store
         parent::__construct($name, $handler, $id);
     }
 
+    #[\Override]
     protected function prepareForStorage($data)
     {
         return $this->encrypter->encrypt($data);
     }
 
+    #[\Override]
     protected function prepareForUnserialize($data)
     {
         try {

--- a/src/Session/FileSessionHandler.php
+++ b/src/Session/FileSessionHandler.php
@@ -8,13 +8,8 @@ use SessionHandlerInterface;
 
 class FileSessionHandler implements SessionHandlerInterface
 {
-    protected $path;
-    protected $prefix;
-
-    public function __construct($path, $prefix = 'lumberjack_session_')
+    public function __construct(protected $path, protected $prefix = 'lumberjack_session_')
     {
-        $this->path = $path;
-        $this->prefix = $prefix;
     }
 
     #[\ReturnTypeWillChange]
@@ -46,7 +41,7 @@ class FileSessionHandler implements SessionHandlerInterface
     {
         try {
             file_put_contents($this->getFilepath($sessionId), $data);
-        } catch (Exception $e) {
+        } catch (Exception) {
             Log::error('Failed to create session on disk');
         }
 

--- a/src/Session/Store.php
+++ b/src/Session/Store.php
@@ -194,7 +194,7 @@ class Store
 
     public function setId($id = null)
     {
-        $id = $id ?? static::random(40);
+        $id ??= static::random(40);
 
         $this->id = $id;
     }

--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -12,20 +12,16 @@ abstract class ViewModel implements Arrayable
     public function toArray() : array
     {
         $propertyKeyValues = collect($this->validPropertyNames())
-            ->mapWithKeys(function ($method) {
-                return [
-                    $method => $this->{$method},
-                ];
-            })
+            ->mapWithKeys(fn($method) => [
+                $method => $this->{$method},
+            ])
             ->toArray();
 
         $methodKeyValues = collect($this->validMethodNames())
             ->whereNotIn(null, $this->ignoredMethods())
-            ->mapWithKeys(function ($method) {
-                return [
-                    $method => call_user_func([$this, $method]),
-                ];
-            })
+            ->mapWithKeys(fn($method) => [
+                $method => call_user_func([$this, $method]),
+            ])
             ->toArray();
 
         return array_merge($propertyKeyValues, $methodKeyValues);
@@ -35,12 +31,8 @@ abstract class ViewModel implements Arrayable
     {
         $class = new ReflectionClass(static::class);
         return collect($class->getMethods(ReflectionMethod::IS_PUBLIC))
-            ->reject(function ($method) {
-                return $method->isStatic() || $method->getNumberOfParameters() > 0;
-            })
-            ->map(function ($method) {
-                return $method->getName();
-            })
+            ->reject(fn($method) => $method->isStatic() || $method->getNumberOfParameters() > 0)
+            ->map(fn($method) => $method->getName())
             ->all();
     }
 
@@ -49,12 +41,8 @@ abstract class ViewModel implements Arrayable
         $class = new ReflectionClass(static::class);
 
         return collect($class->getProperties(ReflectionProperty::IS_PUBLIC))
-            ->reject(function ($property) {
-                return $property->isStatic();
-            })
-            ->map(function ($property) {
-                return $property->getName();
-            })
+            ->reject(fn($property) => $property->isStatic())
+            ->map(fn($property) => $property->getName())
             ->all();
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -5,69 +5,69 @@ use Rareloop\Lumberjack\Helpers;
 if (!function_exists('app')) {
     function app()
     {
-        return call_user_func_array([Helpers::class, 'app'], func_get_args());
+        return call_user_func_array(Helpers::app(...), func_get_args());
     }
 }
 
 if (!function_exists('config')) {
     function config()
     {
-        return call_user_func_array([Helpers::class, 'config'], func_get_args());
+        return call_user_func_array(Helpers::config(...), func_get_args());
     }
 }
 
 if (!function_exists('view')) {
     function view()
     {
-        return call_user_func_array([Helpers::class, 'view'], func_get_args());
+        return call_user_func_array(Helpers::view(...), func_get_args());
     }
 }
 
 if (!function_exists('route')) {
     function route()
     {
-        return call_user_func_array([Helpers::class, 'route'], func_get_args());
+        return call_user_func_array(Helpers::route(...), func_get_args());
     }
 }
 
 if (!function_exists('redirect')) {
     function redirect()
     {
-        return call_user_func_array([Helpers::class, 'redirect'], func_get_args());
+        return call_user_func_array(Helpers::redirect(...), func_get_args());
     }
 }
 
 if (!function_exists('report')) {
     function report()
     {
-        return call_user_func_array([Helpers::class, 'report'], func_get_args());
+        return call_user_func_array(Helpers::report(...), func_get_args());
     }
 }
 
 if (!function_exists('session')) {
     function session()
     {
-        return call_user_func_array([Helpers::class, 'session'], func_get_args());
+        return call_user_func_array(Helpers::session(...), func_get_args());
     }
 }
 
 if (!function_exists('back')) {
     function back()
     {
-        return call_user_func_array([Helpers::class, 'back'], func_get_args());
+        return call_user_func_array(Helpers::back(...), func_get_args());
     }
 }
 
 if (!function_exists('request')) {
     function request()
     {
-        return call_user_func_array([Helpers::class, 'request'], func_get_args());
+        return call_user_func_array(Helpers::request(...), func_get_args());
     }
 }
 
 if (!function_exists('logger')) {
     function logger()
     {
-        return call_user_func_array([Helpers::class, 'logger'], func_get_args());
+        return call_user_func_array(Helpers::logger(...), func_get_args());
     }
 }

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -498,9 +498,7 @@ class ApplicationTest extends TestCase
         $builder->setNamespace($namespace)
             ->setName('php_sapi_name')
             ->setFunction(
-                function () use ($value) {
-                    return $value;
-                }
+                fn() => $value
             );
 
         return $builder->build();
@@ -552,21 +550,15 @@ class ApplicationTest extends TestCase
 
 class BootstrapperBootstrapTester
 {
-    public $callback;
-
-    public function __construct($callback)
+    public function __construct(public $callback)
     {
-        $this->callback = $callback;
     }
 }
 
 abstract class TestBootstrapperBase
 {
-    private BootstrapperBootstrapTester $tester;
-
-    public function __construct(BootstrapperBootstrapTester $tester)
+    public function __construct(private readonly BootstrapperBootstrapTester $tester)
     {
-        $this->tester = $tester;
     }
 
     public function bootstrap(Application $app)
@@ -654,13 +646,9 @@ class NotRegisteredInContainer
 class RequiresAdditionalConstructorParams
 {
     public $param;
-    public $param1;
-    public $param2;
 
-    public function __construct(TestInterface $test, $param1, $param2)
+    public function __construct(TestInterface $test, public $param1, public $param2)
     {
         $this->param = $test;
-        $this->param1 = $param1;
-        $this->param2 = $param2;
     }
 }

--- a/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
+++ b/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
@@ -15,9 +15,9 @@ use Rareloop\Lumberjack\Exceptions\HandlerInterface;
 use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
 use Rareloop\Router\Responsable;
 use Symfony\Component\Debug\Exception\FatalErrorException;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\Response\TextResponse;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
 
 /**
  * @runTestsInSeparateProcesses

--- a/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
+++ b/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
@@ -57,9 +57,7 @@ class RegisterExceptionHandlerTest extends TestCase
         $app->bind('config', $config);
         $app->bind(Config::class, $config);
 
-        $handler->shouldReceive('report')->once()->with(Mockery::on(function ($e) {
-            return $e->getSeverity() === E_USER_NOTICE && $e->getMessage() === 'Test Error';
-        }));
+        $handler->shouldReceive('report')->once()->with(Mockery::on(fn($e) => $e->getSeverity() === E_USER_NOTICE && $e->getMessage() === 'Test Error'));
 
         $bootstrapper = new RegisterExceptionHandler();
         $bootstrapper->bootstrap($app);
@@ -80,9 +78,7 @@ class RegisterExceptionHandlerTest extends TestCase
         $app->bind('config', $config);
         $app->bind(Config::class, $config);
 
-        $handler->shouldReceive('report')->once()->with(Mockery::on(function ($e) {
-            return $e->getSeverity() === E_USER_DEPRECATED && $e->getMessage() === 'Test Error';
-        }));
+        $handler->shouldReceive('report')->once()->with(Mockery::on(fn($e) => $e->getSeverity() === E_USER_DEPRECATED && $e->getMessage() === 'Test Error'));
 
         $bootstrapper = new RegisterExceptionHandler();
         $bootstrapper->bootstrap($app);
@@ -103,9 +99,7 @@ class RegisterExceptionHandlerTest extends TestCase
         $app->bind('config', $config);
         $app->bind(Config::class, $config);
 
-        $handler->shouldReceive('report')->once()->with(Mockery::on(function ($e) {
-            return $e->getSeverity() === E_DEPRECATED && $e->getMessage() === 'Test Error';
-        }));
+        $handler->shouldReceive('report')->once()->with(Mockery::on(fn($e) => $e->getSeverity() === E_DEPRECATED && $e->getMessage() === 'Test Error'));
 
         $bootstrapper = new RegisterExceptionHandler();
         $bootstrapper->bootstrap($app);
@@ -128,9 +122,7 @@ class RegisterExceptionHandlerTest extends TestCase
         $app->bind('config', $config);
         $app->bind(Config::class, $config);
 
-        $handler->shouldReceive('report')->once()->with(Mockery::on(function ($e) {
-            return $e->getSeverity() === E_USER_ERROR && $e->getMessage() === 'Test Error';
-        }));
+        $handler->shouldReceive('report')->once()->with(Mockery::on(fn($e) => $e->getSeverity() === E_USER_ERROR && $e->getMessage() === 'Test Error'));
 
         $bootstrapper = new RegisterExceptionHandler();
         $bootstrapper->bootstrap($app);

--- a/tests/Unit/Bootstrappers/RegisterFacadesTest.php
+++ b/tests/Unit/Bootstrappers/RegisterFacadesTest.php
@@ -2,11 +2,10 @@
 
 namespace Rareloop\Lumberjack\Test\Bootstrappers;
 
-use Blast\Facades\FacadeFactory;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Bootstrappers\RegisterFacades;
+use Rareloop\Lumberjack\FacadeManager;
 
 class RegisterFacadesTest extends TestCase
 {
@@ -18,6 +17,6 @@ class RegisterFacadesTest extends TestCase
         $registerFacadesBootstrapper = new RegisterFacades;
         $registerFacadesBootstrapper->bootstrap($app);
 
-        $this->assertSame($app, FacadeFactory::getContainer());
+        $this->assertSame($app, FacadeManager::getContainer());
     }
 }

--- a/tests/Unit/Exceptions/HandlerTest.php
+++ b/tests/Unit/Exceptions/HandlerTest.php
@@ -9,8 +9,8 @@ use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Config;
 use Rareloop\Lumberjack\Exceptions\Handler;
-use Zend\Diactoros\Response\HtmlResponse;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\ServerRequest;
 
 class HandlerTest extends TestCase
 {
@@ -124,6 +124,4 @@ class HandlerWithBlacklist extends Handler
     ];
 }
 
-class BlacklistedException extends \Exception
-{
-}
+class BlacklistedException extends \Exception {}

--- a/tests/Unit/Exceptions/HandlerTest.php
+++ b/tests/Unit/Exceptions/HandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace Rareloop\Lumberjack\Test\Exceptions;
 
-use Blast\Facades\FacadeFactory;
 use Mockery;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
@@ -11,6 +10,7 @@ use Rareloop\Lumberjack\Config;
 use Rareloop\Lumberjack\Exceptions\Handler;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Diactoros\ServerRequest;
+use Rareloop\Lumberjack\FacadeManager;
 
 class HandlerTest extends TestCase
 {
@@ -52,7 +52,7 @@ class HandlerTest extends TestCase
     public function render_should_return_an_html_response_when_debug_is_enabled()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $config = new Config;
         $config->set('app.debug', true);
         $app->bind('config', $config);
@@ -69,7 +69,7 @@ class HandlerTest extends TestCase
     public function render_should_return_an_html_response_when_debug_is_disabled()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $config = new Config;
         $config->set('app.debug', false);
         $app->bind('config', $config);
@@ -86,7 +86,7 @@ class HandlerTest extends TestCase
     public function render_should_include_stack_trace_when_debug_is_enabled()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $config = new Config;
         $config->set('app.debug', true);
         $app->bind('config', $config);
@@ -103,7 +103,7 @@ class HandlerTest extends TestCase
     public function render_should_not_include_stack_trace_when_debug_is_disabled()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $config = new Config;
         $config->set('app.debug', false);
         $app->bind('config', $config);

--- a/tests/Unit/Facades/ConfigTest.php
+++ b/tests/Unit/Facades/ConfigTest.php
@@ -2,10 +2,10 @@
 
 namespace Rareloop\Lumberjack\Test\Facades;
 
-use Blast\Facades\FacadeFactory;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Config;
+use Rareloop\Lumberjack\FacadeManager;
 use Rareloop\Lumberjack\Facades\Config as ConfigFacade;
 
 class ConfigTest extends TestCase
@@ -14,7 +14,7 @@ class ConfigTest extends TestCase
     public function test_facade()
     {
         $app = new Application();
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $config = new Config();
         $config->set('app.environment', 'production');

--- a/tests/Unit/Facades/FacadeTest.php
+++ b/tests/Unit/Facades/FacadeTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test\Facades;
+
+use DI\Container;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Rareloop\Lumberjack\FacadeManager;
+use Rareloop\Lumberjack\Facades\Facade;
+use Rareloop\Lumberjack\Test\Unit\Facades\Stubs\Foo;
+use Rareloop\Lumberjack\Test\Unit\Facades\Stubs\FooFacade;
+use Rareloop\Lumberjack\Test\Unit\Facades\Stubs\FooInterface;
+
+class FacadeTest extends TestCase
+{
+    private ?Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container();
+        $this->container->set(FooFacade::accessor(), new Foo());
+    }
+
+    /** @test */
+    public function can_initiate_facades()
+    {
+        FacadeManager::setContainer($this->container);
+        $this->assertInstanceOf(ContainerInterface::class, FacadeManager::getContainer());
+    }
+
+    /** @test */
+    public function can_get_facade_instance()
+    {
+        FacadeManager::setContainer($this->container);
+
+        $instance = FooFacade::__instance();
+
+        $this->assertInstanceOf(FooInterface::class, $instance);
+        $this->assertInstanceOf(Foo::class, $instance);
+    }
+
+    /** @test */
+    public function can_swap_instances()
+    {
+        FacadeManager::setContainer($this->container);
+
+        $instance = FooFacade::__instance();
+
+        $this->assertInstanceOf(FooInterface::class, $instance);
+        $this->assertInstanceOf(Foo::class, $instance);
+
+        $this->container->set(FooFacade::accessor(), 'bar');
+
+        $instance = FooFacade::__instance();
+
+        $this->assertEquals('bar', $instance);
+    }
+
+    public function can_call_functions()
+    {
+        FacadeManager::setContainer($this->container);
+
+        $this->assertEquals('bar', forward_static_call([FooFacade::class, 'foo']));
+        $this->assertEquals('bar', call_user_func('FooFacade::class::foo'));
+        $this->assertEquals('bar', FooFacade::foo());
+    }
+}

--- a/tests/Unit/Facades/LogTest.php
+++ b/tests/Unit/Facades/LogTest.php
@@ -2,10 +2,10 @@
 
 namespace Rareloop\Lumberjack\Test\Facades;
 
-use Blast\Facades\FacadeFactory;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Application;
+use Rareloop\Lumberjack\FacadeManager;
 use Rareloop\Lumberjack\Facades\Log as LogFacade;
 
 class LogTest extends TestCase
@@ -14,7 +14,7 @@ class LogTest extends TestCase
     public function test_facade()
     {
         $app = new Application();
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $logger = new Logger('app');
         $app->bind('logger', $logger);

--- a/tests/Unit/Facades/MiddlewareAliasesTest.php
+++ b/tests/Unit/Facades/MiddlewareAliasesTest.php
@@ -2,9 +2,9 @@
 
 namespace Rareloop\Lumberjack\Test\Facades;
 
-use Blast\Facades\FacadeFactory;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Application;
+use Rareloop\Lumberjack\FacadeManager;
 use Rareloop\Lumberjack\Facades\MiddlewareAliases;
 use Rareloop\Lumberjack\Http\MiddlewareAliasStore;
 
@@ -14,7 +14,7 @@ class MiddlewareAliasesTest extends TestCase
     public function test_facade()
     {
         $app = new Application();
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $store = new MiddlewareAliasStore();
         $app->bind('middleware-alias-store', $store);

--- a/tests/Unit/Facades/RouterTest.php
+++ b/tests/Unit/Facades/RouterTest.php
@@ -2,9 +2,9 @@
 
 namespace Rareloop\Lumberjack\Test\Facades;
 
-use Blast\Facades\FacadeFactory;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Application;
+use Rareloop\Lumberjack\FacadeManager;
 use Rareloop\Lumberjack\Facades\Router as RouterFacade;
 use Rareloop\Lumberjack\Http\Router;
 
@@ -14,7 +14,7 @@ class RouterTest extends TestCase
     public function test_facade()
     {
         $app = new Application();
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $router = new Router();
         $app->bind('router', $router);

--- a/tests/Unit/Facades/SessionTest.php
+++ b/tests/Unit/Facades/SessionTest.php
@@ -2,9 +2,9 @@
 
 namespace Rareloop\Lumberjack\Test\Facades;
 
-use Blast\Facades\FacadeFactory;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Application;
+use Rareloop\Lumberjack\FacadeManager;
 use Rareloop\Lumberjack\Facades\Session;
 use Rareloop\Lumberjack\Session\SessionManager;
 use Rareloop\Lumberjack\Test\Unit\Session\NullSessionHandler;
@@ -15,7 +15,7 @@ class SessionTest extends TestCase
     public function test_facade()
     {
         $app = new Application();
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $store = new SessionManager($app);
         $app->bind('session', $store);

--- a/tests/Unit/Facades/Stubs/Foo.php
+++ b/tests/Unit/Facades/Stubs/Foo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test\Unit\Facades\Stubs;
+
+class Foo implements FooInterface
+{
+    public function foo(): string
+    {
+        return 'bar';
+    }
+}

--- a/tests/Unit/Facades/Stubs/FooFacade.php
+++ b/tests/Unit/Facades/Stubs/FooFacade.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test\Unit\Facades\Stubs;
+
+use Rareloop\Lumberjack\Facades\Facade;
+
+class FooFacade extends Facade
+{
+    public static function accessor(): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Unit/Facades/Stubs/FooInterface.php
+++ b/tests/Unit/Facades/Stubs/FooInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rareloop\Lumberjack\Test\Unit\Facades\Stubs;
+
+interface FooInterface
+{
+    public function foo(): string;
+}

--- a/tests/Unit/GlobalFunctionsTest.php
+++ b/tests/Unit/GlobalFunctionsTest.php
@@ -46,8 +46,6 @@ class GlobalFunctionsTest extends TestCase
     {
         $reflection = new \ReflectionClass(Helpers::class);
 
-        return collect($reflection->getMethods(\ReflectionMethod::IS_STATIC))->map(function ($function) {
-            return [$function->name];
-        })->toArray();
+        return collect($reflection->getMethods(\ReflectionMethod::IS_STATIC))->map(fn($function) => [$function->name])->toArray();
     }
 }

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -147,7 +147,7 @@ class HelpersTest extends TestCase
 
         $url = Helpers::route('test.route');
 
-        $this->assertSame('test/route', trim($url, '/'));
+        $this->assertSame('test/route', trim((string) $url, '/'));
     }
 
     /** @test */
@@ -164,7 +164,7 @@ class HelpersTest extends TestCase
             'name' => 'route',
         ]);
 
-        $this->assertSame('test/route', trim($url, '/'));
+        $this->assertSame('test/route', trim((string) $url, '/'));
     }
 
     /** @test */
@@ -207,9 +207,7 @@ class HelpersTest extends TestCase
         $handler = \Mockery::mock(TestExceptionHandler::class . '[report]', [$app]);
         $handler->shouldReceive('report')->with($exception)->once();
 
-        $app->bind(HandlerInterface::class, function () use ($handler) {
-            return $handler;
-        });
+        $app->bind(HandlerInterface::class, fn() => $handler);
 
         Helpers::report($exception);
     }
@@ -375,12 +373,7 @@ class TestExceptionHandler extends Handler
 
 class RequiresConstructorParams
 {
-    public $param1;
-    public $param2;
-
-    public function __construct($param1, $param2)
+    public function __construct(public $param1, public $param2)
     {
-        $this->param1 = $param1;
-        $this->param2 = $param2;
     }
 }

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -6,7 +6,6 @@ use Timber\Timber;
 use Rareloop\Router\Router;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Lumberjack\Config;
-use Blast\Facades\FacadeFactory;
 use Rareloop\Lumberjack\Helpers;
 use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Facades\Session;
@@ -18,6 +17,7 @@ use Rareloop\Lumberjack\Exceptions\HandlerInterface;
 use Rareloop\Lumberjack\Http\Responses\TimberResponse;
 use Rareloop\Lumberjack\Http\Responses\RedirectResponse;
 use Monolog\Logger;
+use Rareloop\Lumberjack\FacadeManager;
 
 /**
  * @runTestsInSeparateProcesses
@@ -48,7 +48,7 @@ class HelpersTest extends TestCase
     public function can_retrieve_a_config_value()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $config = new Config();
         $config->set('app.environment', 'production');
@@ -61,7 +61,7 @@ class HelpersTest extends TestCase
     public function can_retrieve_a_default_when_no_config_value_is_set()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $config = new Config();
         $app->bind('config', $config);
@@ -73,7 +73,7 @@ class HelpersTest extends TestCase
     public function can_set_a_config_value_when_array_passed_to_config_helper()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $config = new Config();
         $app->bind('config', $config);
 
@@ -139,10 +139,9 @@ class HelpersTest extends TestCase
     public function can_get_a_url_for_a_named_route()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $router = new Router;
-        $router->get('test/route', function () {
-        })->name('test.route');
+        $router->get('test/route', function () {})->name('test.route');
         $app->bind('router', $router);
 
         $url = Helpers::route('test.route');
@@ -154,10 +153,9 @@ class HelpersTest extends TestCase
     public function can_get_a_url_for_a_named_route_with_params()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $router = new Router;
-        $router->get('test/{name}', function ($name) {
-        })->name('test.route');
+        $router->get('test/{name}', function ($name) {})->name('test.route');
         $app->bind('router', $router);
 
         $url = Helpers::route('test.route', [
@@ -216,7 +214,7 @@ class HelpersTest extends TestCase
     public function can_access_an_item_in_the_session_by_key()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $store = new SessionManager($app);
         $app->bind('session', $store);
@@ -230,7 +228,7 @@ class HelpersTest extends TestCase
     public function can_access_an_item_in_the_session_by_key_with_default()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $store = new SessionManager($app);
         $app->bind('session', $store);
@@ -242,7 +240,7 @@ class HelpersTest extends TestCase
     public function can_add_an_item_in_the_session()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $store = new SessionManager($app);
         $app->bind('session', $store);
@@ -256,7 +254,7 @@ class HelpersTest extends TestCase
     public function can_add_multiple_items_to_the_session()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $store = new SessionManager($app);
         $app->bind('session', $store);
@@ -271,7 +269,7 @@ class HelpersTest extends TestCase
     public function can_resolve_the_session_manager()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $store = new SessionManager($app);
         $app->bind('session', $store);
@@ -283,7 +281,7 @@ class HelpersTest extends TestCase
     public function can_redirect_back()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
         $store = new SessionManager($app);
         $app->bind('session', $store);
         $store->setPreviousUrl('http://domain.com/previous/url');
@@ -298,7 +296,7 @@ class HelpersTest extends TestCase
     public function can_get_server_request()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $request = new ServerRequest([], [], '/test/123', 'GET');
         $app->bind('request', $request);
@@ -310,7 +308,7 @@ class HelpersTest extends TestCase
     public function can_get_logger()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $logger = new Logger('app');
         $app->bind('logger', $logger);
@@ -325,7 +323,7 @@ class HelpersTest extends TestCase
     public function can_write_debug_log()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $logger = \Mockery::mock(Logger::class)->makePartial();
         $logger->shouldReceive('debug')->with('Example message', [])->once();
@@ -339,7 +337,7 @@ class HelpersTest extends TestCase
     public function can_write_debug_log_with_context()
     {
         $app = new Application;
-        FacadeFactory::setContainer($app);
+        FacadeManager::setContainer($app);
 
         $logger = \Mockery::mock(Logger::class)->makePartial();
         $logger->shouldReceive('debug')->with('Example message', [
@@ -373,7 +371,5 @@ class TestExceptionHandler extends Handler
 
 class RequiresConstructorParams
 {
-    public function __construct(public $param1, public $param2)
-    {
-    }
+    public function __construct(public $param1, public $param2) {}
 }

--- a/tests/Unit/Http/Middleware/PasswordProtectTest.php
+++ b/tests/Unit/Http/Middleware/PasswordProtectTest.php
@@ -52,9 +52,7 @@ class PasswordProtectTest extends TestCase
         $timber = \Mockery::mock('alias:' . Timber::class);
         $timber->shouldReceive('get_post')->once();
         $timber->shouldReceive('compile')
-            ->withArgs(function ($template) {
-                return $template === 'single-password.twig';
-            })
+            ->withArgs(fn($template) => $template === 'single-password.twig')
             ->once()
             ->andReturn(false);
 
@@ -84,9 +82,7 @@ class PasswordProtectTest extends TestCase
         $timber = \Mockery::mock('alias:' . Timber::class);
         $timber->shouldReceive('get_post')->once();
         $timber->shouldReceive('compile')
-            ->withArgs(function ($template) {
-                return $template === 'single-password.twig';
-            })
+            ->withArgs(fn($template) => $template === 'single-password.twig')
             ->once()
             ->andReturn('testing123');
 

--- a/tests/Unit/Http/MiddlewareAliasStoreTest.php
+++ b/tests/Unit/Http/MiddlewareAliasStoreTest.php
@@ -29,9 +29,7 @@ class MiddlewareAliasStoreTest extends TestCase
         $store = new MiddlewareAliasStore;
         $middleware = Mockery::mock(MiddlewareInterface::class);
 
-        $store->set('middlewarekey', function () use ($middleware) {
-            return $middleware;
-        });
+        $store->set('middlewarekey', fn() => $middleware);
 
         $this->assertSame($middleware, $store->get('middlewarekey'));
     }
@@ -108,12 +106,7 @@ class MASTestClass
 
 class MASTestClassWithConstructorParams
 {
-    public $param1;
-    public $param2;
-
-    public function __construct($param1, $param2)
+    public function __construct(public $param1, public $param2)
     {
-        $this->param1 = $param1;
-        $this->param2 = $param2;
     }
 }

--- a/tests/Unit/Http/RouterTest.php
+++ b/tests/Unit/Http/RouterTest.php
@@ -42,7 +42,7 @@ class RouterTest extends TestCase
         $router = new Router;
         $controller = new RouterTestController;
 
-        $route = $router->get('/test/123', [$controller, 'test']);
+        $route = $router->get('/test/123', $controller->test(...));
 
         $this->assertSame(RouterTestController::class . '@test', $route->getActionName());
     }
@@ -63,9 +63,7 @@ class RouterTest extends TestCase
      */
     public function can_extend_post_behaviour_with_macros()
     {
-        Router::macro('testFunctionAddedByMacro', function () {
-            return 'abc123';
-        });
+        Router::macro('testFunctionAddedByMacro', fn() => 'abc123');
 
         $queryBuilder = new Router();
 
@@ -90,9 +88,7 @@ class RouterMixin
 {
     function testFunctionAddedByMixin()
     {
-        return function() {
-            return 'abc123';
-        };
+        return fn() => 'abc123';
     }
 }
 

--- a/tests/Unit/Http/ServerRequestTest.php
+++ b/tests/Unit/Http/ServerRequestTest.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Rareloop\Lumberjack\Http\ServerRequest;
 use Rareloop\Psr7ServerRequestExtension\InteractsWithInput;
 use Rareloop\Psr7ServerRequestExtension\InteractsWithUri;
-use Zend\Diactoros\ServerRequest as DiactorosServerRequest;
+use Laminas\Diactoros\ServerRequest as DiactorosServerRequest;
 
 class ServerRequestTest extends TestCase
 {

--- a/tests/Unit/PostQueryBuilderTest.php
+++ b/tests/Unit/PostQueryBuilderTest.php
@@ -55,7 +55,7 @@ class PostQueryBuilderTest extends TestCase
 
         try {
             Post::missingStaticFunction();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             $errorThrown = true;
         }
 
@@ -84,6 +84,7 @@ class QueryBuilderTestPost extends Post
         static::$injectedBuilder = $builder;
     }
 
+    #[\Override]
     public static function builder(): ScopedQueryBuilder
     {
         return static::$injectedBuilder;

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -30,7 +30,7 @@ class PostTest extends TestCase
 
         RegisterablePostType::register();
 
-        $this->assertNotFalse(has_filter('timber/post/classmap', [RegisterablePostType::class, 'filterTimberPostClassMap']));
+        $this->assertNotFalse(has_filter('timber/post/classmap', RegisterablePostType::filterTimberPostClassMap(...)));
     }
 
     /** @test */
@@ -213,9 +213,7 @@ class PostTest extends TestCase
      */
     public function can_extend_post_behaviour_with_macros()
     {
-        Post::macro('testFunctionAddedByMacro', function () {
-            return 'abc123';
-        });
+        Post::macro('testFunctionAddedByMacro', fn() => 'abc123');
 
         $post = new Post(null, true);
 
@@ -228,9 +226,7 @@ class PostTest extends TestCase
      */
     public function macros_set_correct_this_context_on_instances()
     {
-        PostWithPrivateData::macro('testFunctionAddedByMacro', function () {
-            return $this->dummyData;
-        });
+        PostWithPrivateData::macro('testFunctionAddedByMacro', fn() => $this->dummyData);
 
         $post = new PostWithPrivateData(null, true);
 
@@ -254,9 +250,7 @@ class PostMixin
 {
     function testFunctionAddedByMixin()
     {
-        return function () {
-            return 'abc123';
-        };
+        return fn() => 'abc123';
     }
 }
 
@@ -267,6 +261,7 @@ class PostWithPrivateData extends Post
 
 class RegisterablePostType extends Post
 {
+    #[\Override]
     public static function getPostType(): string
     {
         return 'registerable_post_type';
@@ -317,6 +312,7 @@ class UnregisterablePostTypeWithoutPostType extends Post
 
 class UnregisterablePostTypeWithoutConfig extends Post
 {
+    #[\Override]
     public static function getPostType(): string
     {
         return 'post_type';

--- a/tests/Unit/Providers/CustomPostTypesServiceProviderTest.php
+++ b/tests/Unit/Providers/CustomPostTypesServiceProviderTest.php
@@ -37,6 +37,7 @@ class CustomPostTypesServiceProviderTest extends TestCase
 
 class CustomPost1 extends Post
 {
+    #[\Override]
     public static function getPostType()
     {
         return 'custom_post_1';
@@ -52,6 +53,7 @@ class CustomPost1 extends Post
 
 class CustomPost2 extends Post
 {
+    #[\Override]
     public static function getPostType()
     {
         return 'custom_post_1';

--- a/tests/Unit/Providers/RouterServiceProviderTest.php
+++ b/tests/Unit/Providers/RouterServiceProviderTest.php
@@ -102,9 +102,7 @@ class RouterServiceProviderTest extends TestCase
         $lumberjack->bootstrap();
 
         $router = $app->get('router');
-        $router->get('/test/123', function () {
-            return 'abc123';
-        });
+        $router->get('/test/123', fn() => 'abc123');
 
         $response = $router->match($request);
         $this->assertSame(200, $response->getStatusCode());
@@ -287,13 +285,8 @@ class RouterServiceProviderTest extends TestCase
 
 class RSPAddHeaderMiddleware implements MiddlewareInterface
 {
-    private $key;
-    private $value;
-
-    public function __construct($key, $value)
+    public function __construct(private $key, private $value)
     {
-        $this->key = $key;
-        $this->value = $value;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/tests/Unit/Providers/RouterServiceProviderTest.php
+++ b/tests/Unit/Providers/RouterServiceProviderTest.php
@@ -18,10 +18,10 @@ use Rareloop\Lumberjack\Http\Router;
 use Rareloop\Lumberjack\Providers\RouterServiceProvider;
 use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
 use Rareloop\Router\MiddlewareResolver;
-use Zend\Diactoros\Request;
-use Zend\Diactoros\Response\HtmlResponse;
-use Zend\Diactoros\Response\TextResponse;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
 
 class RouterServiceProviderTest extends TestCase
 {
@@ -79,8 +79,7 @@ class RouterServiceProviderTest extends TestCase
         $store->set('middleware-key', new RSPAddHeaderMiddleware('X-Key', 'abc'));
         $request = new ServerRequest([], [], '/test/123', 'GET');
 
-        $router->get('/test/123', function () {
-        })->middleware('middleware-key');
+        $router->get('/test/123', function () {})->middleware('middleware-key');
         $response = $router->match($request);
 
         $this->assertTrue($response->hasHeader('X-Key'));
@@ -285,9 +284,7 @@ class RouterServiceProviderTest extends TestCase
 
 class RSPAddHeaderMiddleware implements MiddlewareInterface
 {
-    public function __construct(private $key, private $value)
-    {
-    }
+    public function __construct(private $key, private $value) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
+++ b/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
@@ -22,8 +22,8 @@ use Rareloop\Lumberjack\Providers\RouterServiceProvider;
 use Rareloop\Lumberjack\Providers\WordPressControllersServiceProvider;
 use Rareloop\Lumberjack\Test\Unit\BrainMonkeyPHPUnitIntegration;
 use Rareloop\Router\Responsable;
-use Zend\Diactoros\Response\TextResponse;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
 use \Mockery;
 use Rareloop\Lumberjack\Http\Middleware\PasswordProtected;
 
@@ -399,27 +399,19 @@ class WordPressControllersServiceProviderTest extends TestCase
 
 class TestController
 {
-    public function handle()
-    {
-    }
+    public function handle() {}
 }
 
 class TestControllerWithConstructorParams
 {
-    public function __construct(Application $app)
-    {
-    }
+    public function __construct(Application $app) {}
 
-    public function handle()
-    {
-    }
+    public function handle() {}
 }
 
 class TestControllerWithHandleParams
 {
-    public function handle(Application $app)
-    {
-    }
+    public function handle(Application $app) {}
 }
 
 class MyResponsable implements Responsable
@@ -440,16 +432,12 @@ class TestControllerReturningAResponsable
 
 class TestControllerWithMiddleware extends Controller
 {
-    public function handle()
-    {
-    }
+    public function handle() {}
 }
 
 class AddHeaderMiddleware implements MiddlewareInterface
 {
-    public function __construct(private $key, private $value)
-    {
-    }
+    public function __construct(private $key, private $value) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
+++ b/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
@@ -40,7 +40,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app->register($provider);
         $app->boot();
 
-        $this->assertNotFalse(has_filter('template_include', [$provider, 'handleTemplateInclude']));
+        $this->assertNotFalse(has_filter('template_include', $provider->handleTemplateInclude(...)));
     }
 
     /** @test */
@@ -195,7 +195,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestController::class, 'handle');
 
@@ -212,7 +212,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestControllerReturningAResponsable::class, 'handle');
 
@@ -230,7 +230,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestControllerWithConstructorParams::class, 'handle');
 
@@ -247,7 +247,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app = new Application(__DIR__ . '/../');
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestControllerWithHandleParams::class, 'handle');
 
@@ -267,7 +267,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
 
@@ -288,7 +288,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
 
@@ -308,7 +308,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
 
@@ -328,7 +328,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
-        $provider->boot($app);
+        $provider->boot();
 
         $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
 
@@ -358,7 +358,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $routerProvider->register();
         $routerProvider->boot();
-        $provider->boot($app);
+        $provider->boot();
 
         $store = $app->get(MiddlewareAliases::class);
         $store->set('middleware-key', new AddHeaderMiddleware('X-Header', 'testing123'));
@@ -447,13 +447,8 @@ class TestControllerWithMiddleware extends Controller
 
 class AddHeaderMiddleware implements MiddlewareInterface
 {
-    private $key;
-    private $value;
-
-    public function __construct($key, $value)
+    public function __construct(private $key, private $value)
     {
-        $this->key = $key;
-        $this->value = $value;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -526,6 +526,7 @@ class QueryBuilderMixin
 
 class PostWithCustomPostType extends Post
 {
+    #[\Override]
     public static function getPostType()
     {
         return 'post_with_query_scope';

--- a/tests/Unit/ScopedQueryBuilderTest.php
+++ b/tests/Unit/ScopedQueryBuilderTest.php
@@ -114,7 +114,7 @@ class ScopedQueryBuilderTest extends TestCase
         try {
             $builder = new ScopedQueryBuilder(PostWithQueryScope::class);
             $builder->nonExistentScope();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             $errorThrown = true;
         }
 
@@ -161,6 +161,7 @@ class CustomQueryBuilder extends QueryBuilder
 
 class PostWithQueryScope extends Post
 {
+    #[\Override]
     public static function getPostType()
     {
         return 'post_with_query_scope';

--- a/tests/Unit/Session/FileSessionHandlerTest.php
+++ b/tests/Unit/Session/FileSessionHandlerTest.php
@@ -32,7 +32,7 @@ class FileSessionHandlerTest extends TestCase
     {
         $handler = new FileSessionHandler(vfsStream::url('exampleDir'));
 
-        $this->assertTrue($handler->close('save-path', 'session-name'));
+        $this->assertTrue($handler->close());
     }
 
     /** @test */

--- a/tests/Unit/Session/SessionManagerTest.php
+++ b/tests/Unit/Session/SessionManagerTest.php
@@ -74,9 +74,7 @@ class SessionManagerTest extends TestCase
         $app = new Application;
         $manager = new SessionManager($app);
 
-        $manager->extend('test', function () {
-            return new Store('name', new TestSessionHandler);
-        });
+        $manager->extend('test', fn() => new Store('name', new TestSessionHandler));
 
         $this->assertInstanceOf(TestSessionHandler::class, $manager->driver('test')->getHandler());
     }


### PR DESCRIPTION
# Dependency Upgrades

Upgrades major version of most packages.

## Breaking Changes

### PHP - 8.4.x

Support for PHP < 8.4 has been removed.

### Laminas Zend Framework Bridge removed

Any imports that start with `Zend\Diactoros` must be re-written to `Laminas\Diactoros`

### Facades - `blast/facades` removed

Blast facades was 10 years out of date, and has been removed. We've decided to take ownership of this code.

All facades will need to be modified as follows:

```diff
<?php

namespace Rareloop\Lumberjack\Facades;

-use Blast\Facades\AbstractFacade;
+Rareloop\Lumberjack\Facades\Facade;

-class Session extends AbstractFacade
+class Session extends Facade
{
    protected static function accessor()
    {
        return 'session';
    }
}

```

Internally, any calls to `\Blast\Facades\FacadeFactory` should be replaced by `\Rareloop\Lumberjack\FacadeManager`