### PR TITLE
Include E_NOTICE and E_WARNING in default report-only error levels

### DIFF
--- a/src/Bootstrappers/RegisterExceptionHandler.php
+++ b/src/Bootstrappers/RegisterExceptionHandler.php
@@ -97,6 +97,8 @@ class RegisterExceptionHandler
         $exception = new ErrorException($message, 0, $level, $file, $line);
 
         $errorsToReportOnly = $this->app->get('config')->get('app.errors.reportOnly') ?: [
+            E_NOTICE,
+            E_WARNING,
             E_USER_NOTICE,
             E_USER_DEPRECATED,
             E_DEPRECATED

--- a/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
+++ b/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
@@ -45,6 +45,52 @@ class RegisterExceptionHandlerTest extends TestCase
     /**
      * @test
      */
+    public function E_NOTICE_errors_are_not_converted_to_exceptions()
+    {
+        Functions\expect('is_admin')->once()->andReturn(false);
+
+        $app = new Application;
+        $handler = Mockery::mock(HandlerInterface::class);
+        $app->bind(HandlerInterface::class, $handler);
+        $config = new Config();
+        $app->bind('config', $config);
+        $app->bind(Config::class, $config);
+
+        $handler->shouldReceive('report')->once()->with(Mockery::on(function ($e) {
+            return $e->getSeverity() === E_NOTICE && $e->getMessage() === 'Test Error';
+        }));
+
+        $bootstrapper = new RegisterExceptionHandler();
+        $bootstrapper->bootstrap($app);
+        $bootstrapper->handleError(E_NOTICE, 'Test Error');
+    }
+
+    /**
+     * @test
+     */
+    public function E_WARNING_errors_are_not_converted_to_exceptions()
+    {
+        Functions\expect('is_admin')->once()->andReturn(false);
+
+        $app = new Application;
+        $handler = Mockery::mock(HandlerInterface::class);
+        $app->bind(HandlerInterface::class, $handler);
+        $config = new Config();
+        $app->bind('config', $config);
+        $app->bind(Config::class, $config);
+
+        $handler->shouldReceive('report')->once()->with(Mockery::on(function ($e) {
+            return $e->getSeverity() === E_WARNING && $e->getMessage() === 'Test Error';
+        }));
+
+        $bootstrapper = new RegisterExceptionHandler();
+        $bootstrapper->bootstrap($app);
+        $bootstrapper->handleError(E_WARNING, 'Test Error');
+    }
+
+    /**
+     * @test
+     */
     public function E_USER_NOTICE_errors_are_not_converted_to_exceptions()
     {
         Functions\expect('is_admin')->once()->andReturn(false);


### PR DESCRIPTION
The default error handler policy converts E_NOTICE and E_WARNING into ErrorException instances. This "fatalises" non-blocking PHP issues, causing script termination for recoverable events (e.g., undefined array keys). In a WordPress environment, this strictness leads to unnecessary crashes for minor issues that do not inherently prevent a successful response.

Solution: added E_NOTICE and E_WARNING to the default $errorsToReportOnly array in RegisterExceptionHandler::handleError. These levels will now be reported to the configured logger but will no longer throw an exception that halts execution.