### PR TITLE
Tighten PHPCS and improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,8 @@ jobs:
             - name: Configure Git
               run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-            - name: DEBUG
-              run: composer update guzzlehttp/guzzle:7.10.0 --with-all-dependencies -vvv
-
             - name: Install dependencies
-              run: composer update ${{ matrix.composer_flags }}
+              run: composer update ${{ matrix.composer_flags }} --verbose --dry-run
 
             - name: Run lint
               run: composer run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,61 +3,61 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.3'
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "8.3"
 
-    - name: Install dependencies
-      uses: php-actions/composer@v6
-      with:
-        php_version: '8.3'
-        command: install
+            - name: Install dependencies
+              uses: php-actions/composer@v6
+              with:
+                  php_version: "8.3"
+                  command: update
 
-    - name: Run lint
-      run: composer run lint
+            - name: Run lint
+              run: composer run lint
 
-  build:
-    needs: lint
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php_version: [8.3, 8.4, 8.5]
-        composer_flags: ['', '--prefer-lowest']
+    build:
+        needs: lint
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php_version: [8.3, 8.4, 8.5]
+                composer_flags: ["", "--prefer-lowest"]
 
-    steps:
-    - uses: actions/checkout@v6
+        steps:
+            - uses: actions/checkout@v6
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php_version }}
-        extensions: xdebug
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php_version }}
+                  extensions: xdebug
 
-    - name: Install dependencies
-      uses: php-actions/composer@v6
-      with:
-        php_version: ${{ matrix.php_version }}
-        args: ${{ matrix.composer_flags }}
-        command: update
+            - name: Install dependencies
+              uses: php-actions/composer@v6
+              with:
+                  php_version: ${{ matrix.php_version }}
+                  args: ${{ matrix.composer_flags }}
+                  command: update
 
-    - name: Run tests
-      run: ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
-      env:
-          XDEBUG_MODE: coverage
+            - name: Run tests
+              run: ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
+              env:
+                  XDEBUG_MODE: coverage
 
-    # - name: Submit coverage to Coveralls
-    #   # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:
-    #   # https://github.com/coverallsapp/github-action/issues/15
-    #   env:
-    #     COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     COVERALLS_PARALLEL: true
-    #     COVERALLS_FLAG_NAME: ${{ github.job }}-PHP-${{ matrix.php_version }} ${{ matrix.composer_flags }}
-    #   run: |
-    #     composer global require php-coveralls/php-coveralls
-    #     ~/.composer/vendor/bin/php-coveralls -v
+        # - name: Submit coverage to Coveralls
+        #   # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:
+        #   # https://github.com/coverallsapp/github-action/issues/15
+        #   env:
+        #     COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #     COVERALLS_PARALLEL: true
+        #     COVERALLS_FLAG_NAME: ${{ github.job }}-PHP-${{ matrix.php_version }} ${{ matrix.composer_flags }}
+        #   run: |
+        #     composer global require php-coveralls/php-coveralls
+        #     ~/.composer/vendor/bin/php-coveralls -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
                   extensions: xdebug, curl
                   tools: composer
 
-            # - name: Configure Git
-            #   run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
             - name: Install dependencies
               run: composer update ${{ matrix.composer_flags }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
               with:
                   php-version: "8.3"
 
+            - name: Configure directory
+              run: git config --global --add safe.directory /app
+
             - name: Install dependencies
               uses: php-actions/composer@v6
               with:
@@ -22,7 +25,7 @@ jobs:
             - name: Run lint
               run: composer run lint
 
-    build:
+    test:
         needs: lint
         runs-on: ubuntu-latest
         strategy:
@@ -38,6 +41,9 @@ jobs:
               with:
                   php-version: ${{ matrix.php_version }}
                   extensions: xdebug
+
+            - name: Configure directory
+              run: git config --global --add safe.directory /app
 
             - name: Install dependencies
               uses: php-actions/composer@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
                 dependency_type: ["stable", "lowest"]
                 include:
                     - dependency_type: "stable"
-                      composer_flags: "--no-interaction --prefer-dist"
+                      composer_flags: "--no-interaction"
                     - dependency_type: "lowest"
-                      composer_flags: "--no-interaction --prefer-dist --prefer-lowest"
+                      composer_flags: "--no-interaction --prefer-lowest"
 
         steps:
             - uses: actions/checkout@v6
@@ -37,6 +37,27 @@ jobs:
               run: composer run lint
 
             - name: Run tests
-              run: ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
+              run: ./vendor/bin/phpunit--coverage-cobertura ./cobertura.xml
               env:
                   XDEBUG_MODE: coverage
+
+            # - name: Code Coverage Report
+            #   if: matrix.php == '8.3' && matrix.dependency_type == 'stable'
+            #   uses: irongut/CodeCoverageSummary@v1.3.0
+            #   with:
+            #       filename: ./cobertura.xml
+            #       badge: true
+            #       fail_below_min: true
+            #       format: markdown
+            #       hide_branch_rate: false
+            #       hide_complexity: true
+            #       indicators: true
+            #       output: both
+            #       thresholds: "60 80"
+
+            # - name: Add Coverage PR Comment
+            #   if: github.event_name == 'pull_request' && matrix.php == '8.3' && matrix.dependency_type == 'stable'
+            #   uses: marocchino/sticky-pull-request-comment@v2
+            #   with:
+            #       recreate: true
+            #       path: code-coverage-results.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,13 @@ jobs:
               run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
             - name: Install dependencies
-              run: composer update ${{ matrix.composer_flags }} --verbose --dry-run
+              run: composer update ${{ matrix.composer_flags }}
 
             - name: Run lint
-              run: composer run lint
+              run: ./vendor/bin/phpcs
 
             - name: Run tests
-              run: ./vendor/bin/phpunit--coverage-cobertura ./cobertura.xml
+              run: ./vendor/bin/phpunit --coverage-cobertura ./cobertura.xml
               env:
                   XDEBUG_MODE: coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,23 +41,23 @@ jobs:
               env:
                   XDEBUG_MODE: coverage
 
-            # - name: Code Coverage Report
-            #   if: matrix.php == '8.3' && matrix.dependency_type == 'stable'
-            #   uses: irongut/CodeCoverageSummary@v1.3.0
-            #   with:
-            #       filename: ./cobertura.xml
-            #       badge: true
-            #       fail_below_min: true
-            #       format: markdown
-            #       hide_branch_rate: false
-            #       hide_complexity: true
-            #       indicators: true
-            #       output: both
-            #       thresholds: "60 80"
+            - name: Code Coverage Report
+              if: matrix.php == '8.3' && matrix.dependency_type == 'stable'
+              uses: irongut/CodeCoverageSummary@v1.3.0
+              with:
+                  filename: ./cobertura.xml
+                  badge: true
+                  fail_below_min: true
+                  format: markdown
+                  hide_branch_rate: false
+                  hide_complexity: true
+                  indicators: true
+                  output: both
+                  thresholds: "60 80"
 
-            # - name: Add Coverage PR Comment
-            #   if: github.event_name == 'pull_request' && matrix.php == '8.3' && matrix.dependency_type == 'stable'
-            #   uses: marocchino/sticky-pull-request-comment@v2
-            #   with:
-            #       recreate: true
-            #       path: code-coverage-results.md
+            - name: Add Coverage PR Comment
+              if: github.event_name == 'pull_request' && matrix.php == '8.3' && matrix.dependency_type == 'stable'
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  recreate: true
+                  path: code-coverage-results.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,67 +3,40 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-    lint:
+    ci:
+        name: PHP ${{ matrix.php }} ${{ matrix.dependency_type }}
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                php: ["8.3", "8.4", "8.5"]
+                dependency_type: ["stable", "lowest"]
+                include:
+                    - dependency_type: "stable"
+                      composer_flags: "--no-interaction --prefer-dist"
+                    - dependency_type: "lowest"
+                      composer_flags: "--no-interaction --prefer-dist --prefer-lowest"
+
         steps:
             - uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: "8.3"
+                  php-version: ${{ matrix.php }}
+                  extensions: xdebug, mbstring, openssl
+                  tools: composer
 
-            - name: Configure directory
-              run: git config --global --add safe.directory /app
+            - name: Configure Git
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
             - name: Install dependencies
-              uses: php-actions/composer@v6
-              with:
-                  php_version: "8.3"
-                  command: update
+              run: composer update ${{ matrix.composer_flags }}
 
             - name: Run lint
               run: composer run lint
-
-    test:
-        needs: lint
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                php_version: [8.3, 8.4, 8.5]
-                composer_flags: ["", "--prefer-lowest"]
-
-        steps:
-            - uses: actions/checkout@v6
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php_version }}
-                  extensions: xdebug
-
-            - name: Configure directory
-              run: git config --global --add safe.directory /app
-
-            - name: Install dependencies
-              uses: php-actions/composer@v6
-              with:
-                  php_version: ${{ matrix.php_version }}
-                  args: ${{ matrix.composer_flags }}
-                  command: update
 
             - name: Run tests
               run: ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
               env:
                   XDEBUG_MODE: coverage
-
-        # - name: Submit coverage to Coveralls
-        #   # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:
-        #   # https://github.com/coverallsapp/github-action/issues/15
-        #   env:
-        #     COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #     COVERALLS_PARALLEL: true
-        #     COVERALLS_FLAG_NAME: ${{ github.job }}-PHP-${{ matrix.php_version }} ${{ matrix.composer_flags }}
-        #   run: |
-        #     composer global require php-coveralls/php-coveralls
-        #     ~/.composer/vendor/bin/php-coveralls -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,27 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build-test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+
+    - name: Install dependencies
+      uses: php-actions/composer@v6
+      with:
+        php_version: '8.3'
+        command: install
+
+    - name: Run lint
+      run: composer run lint
+
+  build:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,9 +50,6 @@ jobs:
       run: ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
       env:
           XDEBUG_MODE: coverage
-
-    - name: Run Codesniffer
-      run: vendor/bin/phpcs --standard=PSR2 ./src
 
     # - name: Submit coverage to Coveralls
     #   # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: xdebug, mbstring, openssl
+                  extensions: xdebug, curl
                   tools: composer
 
             - name: Configure Git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,16 @@
 name: CI
 
-on: [push, pull_request]
+on:
+    push:
+        branches: [master]
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
 
 jobs:
     ci:
@@ -27,8 +37,8 @@ jobs:
                   extensions: xdebug, curl
                   tools: composer
 
-            - name: Configure Git
-              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+            # - name: Configure Git
+            #   run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
             - name: Install dependencies
               run: composer update ${{ matrix.composer_flags }}
@@ -55,9 +65,8 @@ jobs:
                   output: both
                   thresholds: "60 80"
 
-            - name: Add Coverage PR Comment
-              if: github.event_name == 'pull_request' && matrix.php == '8.3' && matrix.dependency_type == 'stable'
-              uses: marocchino/sticky-pull-request-comment@v2
-              with:
-                  recreate: true
-                  path: code-coverage-results.md
+            - name: Write Coverage to Job Summary
+              if: matrix.php == '8.3' && matrix.dependency_type == 'stable'
+              run: |
+                  echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
+                  cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
                 dependency_type: ["stable", "lowest"]
                 include:
                     - dependency_type: "stable"
-                      composer_flags: "--no-interaction"
+                      composer_flags: "--no-interaction --no-progress"
                     - dependency_type: "lowest"
-                      composer_flags: "--no-interaction --prefer-lowest"
+                      composer_flags: "--no-interaction --no-progress --prefer-lowest"
 
         steps:
             - uses: actions/checkout@v6
@@ -29,6 +29,9 @@ jobs:
 
             - name: Configure Git
               run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: DEBUG
+              run: composer update guzzlehttp/guzzle:7.10.0 --with-all-dependencies -vvv
 
             - name: Install dependencies
               run: composer update ${{ matrix.composer_flags }}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/pipeline": "^10.49",
         "spatie/backtrace": "^1.8.1",
         "illuminate/conditionable": "^10.49",
-        "guzzlehttp/guzzle": "^7.10",
+        "guzzlehttp/guzzle": "^7.10.0",
         "spatie/flare-client-php": "^1.10.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^12.0",
-        "php-coveralls/php-coveralls": "^2.8",
         "mockery/mockery": "^1.6.12",
         "brain/monkey": "^2.6.2",
         "squizlabs/php_codesniffer": "^3.13.4",

--- a/composer.json
+++ b/composer.json
@@ -55,5 +55,9 @@
         "allow-plugins": {
             "composer/installers": true
         }
+    },
+    "scripts": {
+        "lint": "phpcs",
+        "lint-fix": "phpcbf"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
             "composer/installers": true
         }
     },
+    "minimum-stability": "stable",
     "scripts": {
         "lint": "phpcs",
         "lint-fix": "phpcbf"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/pipeline": "^10.49",
         "spatie/backtrace": "^1.8.1",
         "illuminate/conditionable": "^10.49",
-        "guzzlehttp/guzzle": "^7.10",
+        "guzzlehttp/guzzle": "^7.9",
         "spatie/flare-client-php": "^1.10.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/pipeline": "^10.49",
         "spatie/backtrace": "^1.8.1",
         "illuminate/conditionable": "^10.49",
-        "guzzlehttp/guzzle": "^7.10.0",
+        "guzzlehttp/guzzle": "^7.9",
         "spatie/flare-client-php": "^1.10.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/pipeline": "^10.49",
         "spatie/backtrace": "^1.8.1",
         "illuminate/conditionable": "^10.49",
-        "guzzlehttp/guzzle": "^7.9",
+        "guzzlehttp/guzzle": "^7.10",
         "spatie/flare-client-php": "^1.10.1"
     },
     "require-dev": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset name="Lumberjack">
+    <description>Lumberjack Coding Standard</description>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="p"/>
+
+    <!-- Use PSR12 as a base -->
+    <rule ref="PSR12"/>
+
+    <!-- Allow snake_case in tests -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <!-- Allow multiple classes in a file for tests (stubs/mocks) -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <!-- Allow multiple namespaces/classes in a file for tests -->
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+</ruleset>

--- a/src/Config.php
+++ b/src/Config.php
@@ -16,7 +16,7 @@ class Config
         }
     }
 
-    public function set(string $key, $value) : Config
+    public function set(string $key, $value): Config
     {
         Arr::set($this->data, $key, $value);
 
@@ -33,7 +33,7 @@ class Config
         return Arr::has($this->data, $key);
     }
 
-    public function load(string $path) : Config
+    public function load(string $path): Config
     {
         $files = glob($path . '/*.php');
 

--- a/src/Contracts/Arrayable.php
+++ b/src/Contracts/Arrayable.php
@@ -9,5 +9,5 @@ interface Arrayable
      *
      * @return array
      */
-    public function toArray() : array;
+    public function toArray(): array;
 }

--- a/src/Contracts/MiddlewareAliases.php
+++ b/src/Contracts/MiddlewareAliases.php
@@ -6,5 +6,5 @@ interface MiddlewareAliases
 {
     public function set(string $name, $middleware);
     public function get(string $name);
-    public function has(string $name) : bool;
+    public function has(string $name): bool;
 }

--- a/src/Dcrypt/AesCbc.php
+++ b/src/Dcrypt/AesCbc.php
@@ -31,12 +31,12 @@ class AesCbc extends OpensslBridge
      *
      * @var string
      */
-    const CIPHER = 'aes-256-cbc';
+    public const CIPHER = 'aes-256-cbc';
 
     /**
      * Specify sha256 for message authentication
      *
      * @var string
      */
-    const CHKSUM = 'sha256';
+    public const CHKSUM = 'sha256';
 }

--- a/src/Dcrypt/AesCtr.php
+++ b/src/Dcrypt/AesCtr.php
@@ -31,5 +31,5 @@ class AesCtr extends AesCbc
      *
      * @var string
      */
-    const CIPHER = 'aes-256-ctr';
+    public const CIPHER = 'aes-256-ctr';
 }

--- a/src/Dcrypt/Hash.php
+++ b/src/Dcrypt/Hash.php
@@ -33,7 +33,7 @@ namespace Rareloop\Lumberjack\Dcrypt;
  */
 class Hash
 {
-    const ALGO = 'sha256';
+    public const ALGO = 'sha256';
 
     /**
      * Internal function used to build the actual hash.

--- a/src/Dcrypt/OpensslBridge.php
+++ b/src/Dcrypt/OpensslBridge.php
@@ -31,7 +31,7 @@ class OpensslBridge
      * dcrypt\mcrypt and dcrypt\aes. Since v7, this is only needed for backwards
      * compatibility with older versions
      */
-    const RIJNDA = 'rijndael-128';
+    public const RIJNDA = 'rijndael-128';
 
     /**
      * Decrypt cyphertext

--- a/src/Dcrypt/OpensslWrapper.php
+++ b/src/Dcrypt/OpensslWrapper.php
@@ -16,7 +16,6 @@ namespace Rareloop\Lumberjack\Dcrypt;
 
 class OpensslWrapper
 {
-
     /**
      * OpenSSL encrypt wrapper function
      *

--- a/src/Exceptions/CannotRedeclarePostClassOnQueryException.php
+++ b/src/Exceptions/CannotRedeclarePostClassOnQueryException.php
@@ -4,5 +4,4 @@ namespace Rareloop\Lumberjack\Exceptions;
 
 class CannotRedeclarePostClassOnQueryException extends \Exception
 {
-
 }

--- a/src/Exceptions/CannotRedeclarePostTypeOnQueryException.php
+++ b/src/Exceptions/CannotRedeclarePostTypeOnQueryException.php
@@ -4,5 +4,4 @@ namespace Rareloop\Lumberjack\Exceptions;
 
 class CannotRedeclarePostTypeOnQueryException extends \Exception
 {
-
 }

--- a/src/Exceptions/HandlerInterface.php
+++ b/src/Exceptions/HandlerInterface.php
@@ -10,5 +10,5 @@ interface HandlerInterface
 {
     public function report(Exception $e);
 
-    public function render(ServerRequestInterface $request, Exception $e) : ResponseInterface;
+    public function render(ServerRequestInterface $request, Exception $e): ResponseInterface;
 }

--- a/src/Exceptions/InvalidMetaRelationshipException.php
+++ b/src/Exceptions/InvalidMetaRelationshipException.php
@@ -4,5 +4,4 @@ namespace Rareloop\Lumberjack\Exceptions;
 
 class InvalidMetaRelationshipException extends \Exception
 {
-
 }

--- a/src/Exceptions/PostTypeRegistrationException.php
+++ b/src/Exceptions/PostTypeRegistrationException.php
@@ -4,5 +4,4 @@ namespace Rareloop\Lumberjack\Exceptions;
 
 class PostTypeRegistrationException extends \Exception
 {
-
 }

--- a/src/Exceptions/TwigTemplateNotFoundException.php
+++ b/src/Exceptions/TwigTemplateNotFoundException.php
@@ -4,5 +4,4 @@ namespace Rareloop\Lumberjack\Exceptions;
 
 class TwigTemplateNotFoundException extends \Exception
 {
-
 }

--- a/src/Http/Controller.php
+++ b/src/Http/Controller.php
@@ -6,5 +6,4 @@ use Rareloop\Router\Controller as BaseController;
 
 class Controller extends BaseController
 {
-
 }

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -33,7 +33,7 @@ class Router extends RareRouter
      * @param  mixed  $callback
      * @return boolean
      */
-    private function isControllerString($callback) : bool
+    private function isControllerString($callback): bool
     {
         return is_string($callback) && str_contains($callback, '@');
     }
@@ -44,7 +44,7 @@ class Router extends RareRouter
      * @param  string $callback
      * @return string
      */
-    private function normaliseCallbackString(string $callback) : string
+    private function normaliseCallbackString(string $callback): string
     {
         @list($controller, $method) = explode('@', $callback);
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -9,7 +9,8 @@ use Laminas\Diactoros\ServerRequest as DiactorosServerRequest;
 
 class ServerRequest extends DiactorosServerRequest
 {
-    use InteractsWithInput, InteractsWithUri;
+    use InteractsWithInput;
+    use InteractsWithUri;
 
     public static function fromRequest(ServerRequestInterface $request)
     {

--- a/src/Providers/RouterServiceProvider.php
+++ b/src/Providers/RouterServiceProvider.php
@@ -15,7 +15,7 @@ class RouterServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $store = new MiddlewareAliasStore;
+        $store = new MiddlewareAliasStore();
         $resolver = new MiddlewareResolver($this->app, $store);
 
         $router = new Router($this->app, $resolver);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -36,15 +36,15 @@ class QueryBuilder implements QueryBuilderContract
     private $params = [];
 
     // Order Directions
-    const DESC = 'DESC';
-    const ASC = 'ASC';
+    public const DESC = 'DESC';
+    public const ASC = 'ASC';
 
     // Field Types
-    const NUMERIC = 'numeric';
+    public const NUMERIC = 'numeric';
 
     // Logical Operators
-    const OR = 'OR';
-    const AND = 'AND';
+    public const OR = 'OR';
+    public const AND = 'AND';
 
     public function getParameters(): array
     {

--- a/src/ScopedQueryBuilder.php
+++ b/src/ScopedQueryBuilder.php
@@ -75,6 +75,6 @@ class ScopedQueryBuilder
 
     public function wherePostType($postType)
     {
-        throw new CannotRedeclarePostTypeOnQueryException;
+        throw new CannotRedeclarePostTypeOnQueryException();
     }
 }

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -51,7 +51,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_a_value()
     {
-        $app = new Application;
+        $app = new Application();
 
         $app->bind('app.environment', 'production');
 
@@ -61,7 +61,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_determine_if_something_has_been_bound()
     {
-        $app = new Application;
+        $app = new Application();
 
         $this->assertFalse($app->has('app.environment'));
         $app->bind('app.environment', 'production');
@@ -71,8 +71,8 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_an_object()
     {
-        $app = new Application;
-        $object = new TestInterfaceImplementation;
+        $app = new Application();
+        $object = new TestInterfaceImplementation();
 
         $app->bind('test', $object);
 
@@ -82,8 +82,8 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_an_object_and_always_get_the_same_instance_back()
     {
-        $app = new Application;
-        $object = new TestInterfaceImplementation;
+        $app = new Application();
+        $object = new TestInterfaceImplementation();
 
         $app->bind(TestInterface::class, $object);
 
@@ -93,7 +93,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_a_concrete_class_to_an_interface()
     {
-        $app = new Application;
+        $app = new Application();
 
         $app->bind(TestInterface::class, TestInterfaceImplementation::class);
         $object = $app->get(TestInterface::class);
@@ -105,7 +105,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_using_closure()
     {
-        $app = new Application;
+        $app = new Application();
         $count = 0;
 
         $app->bind(TestInterface::class, function () use (&$count) {
@@ -123,7 +123,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_using_closure_and_get_dependencies_injected()
     {
-        $app = new Application;
+        $app = new Application();
         $count = 0;
 
         $app->bind(TestSubInterface::class, TestSubInterfaceImplementation::class);
@@ -143,7 +143,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_a_singleton_concrete_class_to_an_interface()
     {
-        $app = new Application;
+        $app = new Application();
 
         $app->singleton(TestInterface::class, TestInterfaceImplementation::class);
 
@@ -160,7 +160,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_a_singleton_concrete_class_with_constructor_params_to_an_interface()
     {
-        $app = new Application;
+        $app = new Application();
 
         $app->singleton(TestInterface::class, TestInterfaceImplementationWithConstructorParams::class);
 
@@ -177,7 +177,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_a_singleton_with_closure()
     {
-        $app = new Application;
+        $app = new Application();
         $count = 0;
 
         $app->singleton(TestInterface::class, function () use (&$count) {
@@ -199,7 +199,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bind_a_singleton_and_get_dependencies_injected()
     {
-        $app = new Application;
+        $app = new Application();
         $count = 0;
 
         $app->bind(TestSubInterface::class, TestSubInterfaceImplementation::class);
@@ -224,7 +224,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function app_should_be_bound_into_the_container_on_construction()
     {
-        $app = new Application;
+        $app = new Application();
 
         $this->assertSame($app, $app->get(Application::class));
     }
@@ -232,7 +232,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_create_a_class_that_has_not_been_registered()
     {
-        $app = new Application;
+        $app = new Application();
         $app->bind(TestInterface::class, TestInterfaceImplementation::class);
 
         $object = $app->get(NotRegisteredInContainer::class);
@@ -244,7 +244,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_make_a_class_with_additional_params_for_the_constructor()
     {
-        $app = new Application;
+        $app = new Application();
         $app->bind(TestInterface::class, TestInterfaceImplementation::class);
 
         $object = $app->make(RequiresAdditionalConstructorParams::class, [
@@ -261,7 +261,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function make_produces_unique_instances_of_the_bound_object()
     {
-        $app = new Application;
+        $app = new Application();
         $app->bind(TestInterface::class, TestInterfaceImplementation::class);
 
         $object1 = $app->make(TestInterface::class);
@@ -273,7 +273,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function using_bind_does_not_produce_a_singleton()
     {
-        $app = new Application;
+        $app = new Application();
         $app->bind(TestInterface::class, TestInterfaceImplementation::class);
 
         $object1 = $app->get(TestInterface::class);
@@ -285,7 +285,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function get_does_not_produce_a_singleton_when_the_key_has_not_been_previously_bound_to_the_container()
     {
-        $app = new Application;
+        $app = new Application();
 
         $object1 = $app->get(TestInterfaceImplementation::class);
         $object2 = $app->get(TestInterfaceImplementation::class);
@@ -297,10 +297,10 @@ class ApplicationTest extends TestCase
     public function using_bind_with_closure_does_not_produce_a_singleton()
     {
         $count = 0;
-        $app = new Application;
+        $app = new Application();
         $app->bind(TestInterface::class, function () use (&$count) {
             $count++;
-            return new TestInterfaceImplementation;
+            return new TestInterfaceImplementation();
         });
 
         $object1 = $app->get(TestInterface::class);
@@ -313,7 +313,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_register_a_service_provider()
     {
-        $app = new Application;
+        $app = new Application();
         $app->register(TestServiceProvider::class);
 
         $providers = $app->getLoadedProviders();
@@ -325,7 +325,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function registered_service_provider_is_returned_by_register()
     {
-        $app = new Application;
+        $app = new Application();
 
         $provider = $app->register(TestServiceProvider::class);
 
@@ -335,7 +335,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_retrieve_a_registered_service_provider()
     {
-        $app = new Application;
+        $app = new Application();
 
         $provider = $app->register(TestServiceProvider::class);
 
@@ -346,7 +346,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_retrieve_a_registered_service_provider_by_object()
     {
-        $app = new Application;
+        $app = new Application();
 
         $provider = $app->register(TestServiceProvider::class);
 
@@ -357,7 +357,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_not_register_the_same_service_provider_twice()
     {
-        $app = new Application;
+        $app = new Application();
 
         $provider1 = $app->register(TestServiceProvider::class);
         $provider2 = $app->register(TestServiceProvider::class);
@@ -372,7 +372,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function service_providers_without_register_functions_dont_cause_an_exception()
     {
-        $app = new Application;
+        $app = new Application();
         $app->register(EmptyServiceProvider::class);
 
         $this->addToAssertionCount(1);  // does not throw an exception
@@ -381,7 +381,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_register_service_provider_from_an_object()
     {
-        $app = new Application;
+        $app = new Application();
         $app->register(new TestServiceProvider($app));
 
         $providers = $app->getLoadedProviders();
@@ -393,7 +393,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function registered_service_providers_have_their_register_function_called()
     {
-        $app = new Application;
+        $app = new Application();
         $provider = Mockery::mock(TestServiceProvider::class, [$app]);
         $provider->shouldReceive('register')->once();
 
@@ -403,7 +403,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function calling_boot_on_app_should_call_boot_on_all_registered_service_providers()
     {
-        $app = new Application;
+        $app = new Application();
         $provider = Mockery::mock(TestServiceProvider::class, [$app]);
         $provider->shouldReceive('register');
         $provider->shouldReceive('boot')->once();
@@ -415,7 +415,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function calling_boot_multiple_times_should_not_fire_boot_on_service_providers_more_than_once()
     {
-        $app = new Application;
+        $app = new Application();
         $provider = Mockery::mock(TestServiceProvider::class, [$app]);
         $provider->shouldReceive('register');
         $provider->shouldReceive('boot')->once();
@@ -428,7 +428,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function boot_should_resolve_dependencies_from_container_on_service_providers()
     {
-        $app = new Application;
+        $app = new Application();
         $app->bind(TestInterface::class, TestInterfaceImplementation::class);
         $provider = new TestBootServiceProvider($app);
         $count = 0;
@@ -450,7 +450,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function services_registered_after_boot_should_have_their_boot_method_called_straight_away()
     {
-        $app = new Application;
+        $app = new Application();
         $provider = Mockery::mock(TestServiceProvider::class, [$app]);
         $provider->shouldReceive('register');
         $provider->shouldReceive('boot')->once();
@@ -462,7 +462,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function is_booted_returns_false_before_boot_method_has_been_called()
     {
-        $app = new Application;
+        $app = new Application();
 
         $this->assertFalse($app->isBooted());
     }
@@ -470,7 +470,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function is_booted_returns_true_after_boot_method_has_been_called()
     {
-        $app = new Application;
+        $app = new Application();
 
         $app->boot();
 
@@ -480,7 +480,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_bootstrap_the_app_with_an_array_of_bootstrappers()
     {
-        $app = new Application;
+        $app = new Application();
         $count = 0;
         $tester = new BootstrapperBootstrapTester(function () use (&$count) {
             $count++;
@@ -512,7 +512,7 @@ class ApplicationTest extends TestCase
     {
         $mock = $this->createPhpSapiNameMock('cli', 'Rareloop\Lumberjack');
         $mock->enable();
-        $app = new Application;
+        $app = new Application();
 
         $this->assertTrue($app->runningInConsole());
     }
@@ -522,7 +522,7 @@ class ApplicationTest extends TestCase
     {
         $mock = $this->createPhpSapiNameMock('phpdbg', 'Rareloop\Lumberjack');
         $mock->enable();
-        $app = new Application;
+        $app = new Application();
 
         $this->assertTrue($app->runningInConsole());
     }
@@ -530,7 +530,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function can_test_if_request_has_been_handled()
     {
-        $app = new Application;
+        $app = new Application();
 
         $this->assertFalse($app->hasRequestBeenHandled());
 
@@ -542,7 +542,7 @@ class ApplicationTest extends TestCase
     #[Test]
     public function calling_detectWhenRequestHasNotBeenHandled_adds_actions()
     {
-        $app = new Application;
+        $app = new Application();
 
         $app->detectWhenRequestHasNotBeenHandled();
 
@@ -573,12 +573,16 @@ class ApplicationTest extends TestCase
 
 class BootstrapperBootstrapTester
 {
-    public function __construct(public $callback) {}
+    public function __construct(public $callback)
+    {
+    }
 }
 
 abstract class TestBootstrapperBase
 {
-    public function __construct(private BootstrapperBootstrapTester $tester) {}
+    public function __construct(private BootstrapperBootstrapTester $tester)
+    {
+    }
 
     public function bootstrap(Application $app)
     {
@@ -586,36 +590,58 @@ abstract class TestBootstrapperBase
     }
 }
 
-class TestBootstrapper1 extends TestBootstrapperBase {}
+class TestBootstrapper1 extends TestBootstrapperBase
+{
+}
 
-class TestBootstrapper2 extends TestBootstrapperBase {}
+class TestBootstrapper2 extends TestBootstrapperBase
+{
+}
 
-interface TestInterface {}
+interface TestInterface
+{
+}
 
-class TestInterfaceImplementation implements TestInterface {}
+class TestInterfaceImplementation implements TestInterface
+{
+}
 
 class TestInterfaceImplementationWithConstructorParams implements TestInterface
 {
-    public function __construct(TestServiceProvider $provider) {}
+    public function __construct(TestServiceProvider $provider)
+    {
+    }
 }
 
-interface TestSubInterface {}
+interface TestSubInterface
+{
+}
 
-class TestSubInterfaceImplementation implements TestSubInterface {}
+class TestSubInterfaceImplementation implements TestSubInterface
+{
+}
 
 class TestServiceProvider extends ServiceProvider
 {
-    public function register() {}
-    public function boot() {}
+    public function register()
+    {
+    }
+    public function boot()
+    {
+    }
 }
 
-class EmptyServiceProvider extends ServiceProvider {}
+class EmptyServiceProvider extends ServiceProvider
+{
+}
 
 class TestBootServiceProvider extends ServiceProvider
 {
     private $bootCallback;
 
-    public function register() {}
+    public function register()
+    {
+    }
 
     public function boot(Application $app, TestInterface $test)
     {

--- a/tests/Unit/Bootstrappers/BootProvidersTest.php
+++ b/tests/Unit/Bootstrappers/BootProvidersTest.php
@@ -17,27 +17,31 @@ class BootProvidersTest extends TestCase
     #[Test]
     public function boots_all_registered_providers()
     {
-        $app = new Application;
+        $app = new Application();
 
-        $provider1 = Mockery::mock(new TestServiceProvider1);
+        $provider1 = Mockery::mock(new TestServiceProvider1());
         $provider1->shouldReceive('boot')->with($app)->once();
-        $provider2 = Mockery::mock(new TestServiceProvider2);
+        $provider2 = Mockery::mock(new TestServiceProvider2());
         $provider2->shouldReceive('boot')->with($app)->once();
 
         $app->register($provider1);
         $app->register($provider2);
 
-        $bootProvidersBootstrapper = new BootProviders;
+        $bootProvidersBootstrapper = new BootProviders();
         $bootProvidersBootstrapper->bootstrap($app);
     }
 }
 
 class TestServiceProvider1
 {
-    public function boot(Application $app) {}
+    public function boot(Application $app)
+    {
+    }
 }
 
 class TestServiceProvider2
 {
-    public function boot(Application $app) {}
+    public function boot(Application $app)
+    {
+    }
 }

--- a/tests/Unit/Bootstrappers/LoadConfigurationTest.php
+++ b/tests/Unit/Bootstrappers/LoadConfigurationTest.php
@@ -14,7 +14,7 @@ class LoadConfigurationTest extends TestCase
     public function adds_config_object_to_the_container()
     {
         $app = new Application(__DIR__ . '/../');
-        $bootstrapper = new LoadConfiguration;
+        $bootstrapper = new LoadConfiguration();
 
         $bootstrapper->bootstrap($app);
 
@@ -27,7 +27,7 @@ class LoadConfigurationTest extends TestCase
     public function created_config_object_has_loaded_config()
     {
         $app = new Application(__DIR__ . '/../');
-        $bootstrapper = new LoadConfiguration;
+        $bootstrapper = new LoadConfiguration();
 
         $bootstrapper->bootstrap($app);
         $config = $app->get('config');

--- a/tests/Unit/Bootstrappers/RegisterAliasesTest.php
+++ b/tests/Unit/Bootstrappers/RegisterAliasesTest.php
@@ -14,19 +14,21 @@ class RegisterAliasesTest extends TestCase
     #[Test]
     public function calls_class_alias_on_all_alias_mappings()
     {
-        $app = new Application;
-        $config = new Config;
+        $app = new Application();
+        $config = new Config();
         $config->set('app.aliases', [
             'Foo' => TestClassToAlias::class,
         ]);
         $app->bind('config', $config);
 
-        $bootstrapper = new RegisterAliases;
+        $bootstrapper = new RegisterAliases();
         $bootstrapper->bootstrap($app);
 
         $this->assertTrue(class_exists('Foo'));
-        $this->assertInstanceOf(TestClassToAlias::class, new \Foo);
+        $this->assertInstanceOf(TestClassToAlias::class, new \Foo());
     }
 }
 
-class TestClassToAlias {}
+class TestClassToAlias
+{
+}

--- a/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
+++ b/tests/Unit/Bootstrappers/RegisterExceptionHandlerTest.php
@@ -34,7 +34,7 @@ class RegisterExceptionHandlerTest extends TestCase
         $this->expectException(\ErrorException::class);
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
         $config = new Config();
         $app->bind('config', $config);
         $app->bind(Config::class, $config);
@@ -49,7 +49,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
         $handler = Mockery::mock(HandlerInterface::class);
         $app->bind(HandlerInterface::class, $handler);
         $config = new Config();
@@ -70,7 +70,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
         $handler = Mockery::mock(HandlerInterface::class);
         $app->bind(HandlerInterface::class, $handler);
         $config = new Config();
@@ -91,7 +91,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
         $handler = Mockery::mock(HandlerInterface::class);
         $app->bind(HandlerInterface::class, $handler);
         $config = new Config();
@@ -112,7 +112,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
         $handler = Mockery::mock(HandlerInterface::class);
         $app->bind(HandlerInterface::class, $handler);
         $config = new Config();
@@ -133,7 +133,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
         $handler = Mockery::mock(HandlerInterface::class);
         $app->bind(HandlerInterface::class, $handler);
         $config = new Config();
@@ -155,7 +155,7 @@ class RegisterExceptionHandlerTest extends TestCase
         $this->expectException(\ErrorException::class);
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
         $handler = Mockery::mock(HandlerInterface::class);
         $app->bind(HandlerInterface::class, $handler);
         $config = new Config();
@@ -178,7 +178,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
 
         $exception = new \Exception('Test Exception');
         $request = new ServerRequest([], [], '/test/123', 'GET');
@@ -201,7 +201,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
 
         $error = new \Error('Test Exception');
         $request = new ServerRequest([], [], '/test/123', 'GET');
@@ -209,7 +209,10 @@ class RegisterExceptionHandlerTest extends TestCase
 
         $handler = Mockery::mock(Handler::class);
         $handler->shouldReceive('report')->with(Mockery::type(\ErrorException::class))->once();
-        $handler->shouldReceive('render')->with($request, Mockery::type(\ErrorException::class))->once()->andReturn(new Response());
+        $handler->shouldReceive('render')
+            ->with($request, Mockery::type(\ErrorException::class))
+            ->once()
+            ->andReturn(new Response());
         $app->bind(HandlerInterface::class, $handler);
 
         $bootstrapper = Mockery::mock(RegisterExceptionHandler::class . '[send]', [$app, new ResponseEmitter()]);
@@ -220,17 +223,20 @@ class RegisterExceptionHandlerTest extends TestCase
     }
 
     #[Test]
-    public function handle_exception_should_call_handlers_report_and_render_methods_even_if_request_is_not_set_in_the_container()
+    public function handle_exception_calls_handler_report_and_render_even_if_request_is_not_set()
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
 
         $exception = new \Exception('Test Exception');
 
         $handler = Mockery::mock(Handler::class);
         $handler->shouldReceive('report')->with($exception)->once();
-        $handler->shouldReceive('render')->with(Mockery::type(ServerRequest::class), $exception)->once()->andReturn(new Response());
+        $handler->shouldReceive('render')
+            ->with(Mockery::type(ServerRequest::class), $exception)
+            ->once()
+            ->andReturn(new Response());
         $app->bind(HandlerInterface::class, $handler);
 
         $bootstrapper = Mockery::mock(RegisterExceptionHandler::class . '[send]', [$app, new ResponseEmitter()]);
@@ -245,7 +251,7 @@ class RegisterExceptionHandlerTest extends TestCase
     {
         Functions\expect('is_admin')->once()->andReturn(false);
 
-        $app = new Application;
+        $app = new Application();
 
         $request = new ServerRequest([], [], '/test/123', 'GET');
         $app->bind('request', $request);
@@ -268,7 +274,7 @@ class RegisterExceptionHandlerTest extends TestCase
     #[Test]
     public function send_should_use_the_emitter()
     {
-        $app = new Application;
+        $app = new Application();
         $response = new TextResponse('Hello World');
         $emitter = Mockery::mock(ResponseEmitter::class);
         $emitter->shouldReceive('emit')->once()->with($response);

--- a/tests/Unit/Bootstrappers/RegisterFacadesTest.php
+++ b/tests/Unit/Bootstrappers/RegisterFacadesTest.php
@@ -13,9 +13,9 @@ class RegisterFacadesTest extends TestCase
     #[Test]
     public function boots_all_registered_providers()
     {
-        $app = new Application;
+        $app = new Application();
 
-        $registerFacadesBootstrapper = new RegisterFacades;
+        $registerFacadesBootstrapper = new RegisterFacades();
         $registerFacadesBootstrapper->bootstrap($app);
 
         $this->assertSame($app, FacadeFactory::getContainer());

--- a/tests/Unit/Bootstrappers/RegisterProvidersTest.php
+++ b/tests/Unit/Bootstrappers/RegisterProvidersTest.php
@@ -18,33 +18,33 @@ class RegisterProvidersTest extends TestCase
     #[Test]
     public function registers_all_providers_found_in_config()
     {
-        $app = new Application;
+        $app = new Application();
 
         $provider1 = Mockery::mock(RPTestServiceProvider1::class, [$app]);
         $provider1->shouldReceive('register')->once();
         $provider2 = Mockery::mock(RPTestServiceProvider2::class, [$app]);
         $provider2->shouldReceive('register')->once();
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.providers', [
             $provider1,
             $provider2,
         ]);
         $app->bind('config', $config);
 
-        $registerProvidersBootstrapper = new RegisterProviders;
+        $registerProvidersBootstrapper = new RegisterProviders();
         $registerProvidersBootstrapper->bootstrap($app);
     }
 
     #[Test]
     public function should_not_fall_over_on_empty_config_data()
     {
-        $app = new Application;
+        $app = new Application();
 
-        $config = new Config;
+        $config = new Config();
         $app->bind('config', $config);
 
-        $registerProvidersBootstrapper = new RegisterProviders;
+        $registerProvidersBootstrapper = new RegisterProviders();
         $registerProvidersBootstrapper->bootstrap($app);
 
         $this->addToAssertionCount(1);  // does not throw an exception
@@ -53,10 +53,14 @@ class RegisterProvidersTest extends TestCase
 
 class RPTestServiceProvider1 extends ServiceProvider
 {
-    public function register() {}
+    public function register()
+    {
+    }
 }
 
 class RPTestServiceProvider2 extends ServiceProvider
 {
-    public function register() {}
+    public function register()
+    {
+    }
 }

--- a/tests/Unit/Bootstrappers/RegisterRequestHandlerTest.php
+++ b/tests/Unit/Bootstrappers/RegisterRequestHandlerTest.php
@@ -19,11 +19,11 @@ class RegisterRequestHandlerTest extends TestCase
         $app = Mockery::mock(Application::class . '[detectWhenRequestHasNotBeenHandled]');
         $app->shouldReceive('detectWhenRequestHasNotBeenHandled')->once();
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.debug', true);
         $app->bind('config', $config);
 
-        $bootstrapper = new RegisterRequestHandler;
+        $bootstrapper = new RegisterRequestHandler();
         $bootstrapper->bootstrap($app);
     }
 
@@ -33,11 +33,11 @@ class RegisterRequestHandlerTest extends TestCase
         $app = Mockery::mock(Application::class . '[detectWhenRequestHasNotBeenHandled]');
         $app->shouldNotReceive('detectWhenRequestHasNotBeenHandled');
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.debug', false);
         $app->bind('config', $config);
 
-        $bootstrapper = new RegisterRequestHandler;
+        $bootstrapper = new RegisterRequestHandler();
         $bootstrapper->bootstrap($app);
     }
 }

--- a/tests/Unit/Concerns/ArraySubsetAsserts.php
+++ b/tests/Unit/Concerns/ArraySubsetAsserts.php
@@ -27,7 +27,10 @@ trait ArraySubsetAsserts
         foreach ($subset as $key => $value) {
             Assert::assertArrayHasKey($key, $array, $message);
 
-            if ((is_array($value) || $value instanceof \ArrayAccess) && (is_array($array[$key]) || $array[$key] instanceof \ArrayAccess)) {
+            if (
+                (is_array($value) || $value instanceof \ArrayAccess) &&
+                (is_array($array[$key]) || $array[$key] instanceof \ArrayAccess)
+            ) {
                 $this->assertArraySubset($value, $array[$key], $checkForObjectIdentity, $message);
             } else {
                 if ($checkForObjectIdentity) {

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -11,7 +11,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function config_values_can_be_set_and_get()
     {
-        $config = new Config;
+        $config = new Config();
 
         $config->set('app.environment', 'production');
 
@@ -21,7 +21,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function get_returns_default_when_no_value_is_set()
     {
-        $config = new Config;
+        $config = new Config();
 
         $this->assertNull($config->get('app.environment'));
         $this->assertSame('production', $config->get('app.environment', 'production'));
@@ -30,7 +30,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function get_ignores_default_when_value_is_set()
     {
-        $config = new Config;
+        $config = new Config();
 
         $config->set('app.environment', 'production');
 
@@ -40,7 +40,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function get_returns_default_when_using_dot_notation_but_not_an_array()
     {
-        $config = new Config;
+        $config = new Config();
 
         $config->set('app.logs', 'app.log');
 
@@ -50,7 +50,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function set_is_chainable()
     {
-        $config = new Config;
+        $config = new Config();
 
         $this->assertSame($config, $config->set('app.environment', 'production'));
     }
@@ -58,7 +58,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function can_read_config_from_files()
     {
-        $config = new Config;
+        $config = new Config();
 
         $config->load(__DIR__ . '/config');
 
@@ -80,7 +80,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function read_is_chainable()
     {
-        $config = new Config;
+        $config = new Config();
 
         $this->assertSame($config, $config->load(__DIR__ . '/config'));
     }
@@ -88,7 +88,7 @@ class ConfigTest extends TestCase
     #[Test]
     public function config_values_can_be_checked_for_existence()
     {
-        $config = new Config;
+        $config = new Config();
 
         $config->set('app.environment', 'production');
         $config->set('app.null', null);

--- a/tests/Unit/Dcrypt/AesCbcTest.php
+++ b/tests/Unit/Dcrypt/AesCbcTest.php
@@ -42,7 +42,9 @@ class AesCbcTest extends TestSupport
     {
         $input = 'hello world';
         $pass = 'password';
-        $vector = \base64_decode('eZu2DqB2gYhdA2YkjagLNJJVMVo1BbpJ75tW/PO2bGIY98XHD+Gp+YlO5cv/rHzo45LHMCxL2qOircdST1w5hg==');
+        $vector = \base64_decode(
+            'eZu2DqB2gYhdA2YkjagLNJJVMVo1BbpJ75tW/PO2bGIY98XHD+Gp+YlO5cv/rHzo45LHMCxL2qOircdST1w5hg=='
+        );
 
         $this->assertEquals($input, AesCbc::decrypt($vector, $pass));
     }

--- a/tests/Unit/Dcrypt/AesCtrTest.php
+++ b/tests/Unit/Dcrypt/AesCtrTest.php
@@ -6,7 +6,8 @@ use Rareloop\Lumberjack\Dcrypt\AesCtr;
 
 class AesCtrTest extends TestSupport
 {
-    private $input = 'AAAAAAAA', $key = 'BBBBBBBB';
+    private $input = 'AAAAAAAA';
+    private $key = 'BBBBBBBB';
 
     public function testPbkdf()
     {

--- a/tests/Unit/Dcrypt/HashTest.php
+++ b/tests/Unit/Dcrypt/HashTest.php
@@ -6,7 +6,6 @@ use Rareloop\Lumberjack\Dcrypt\Hash;
 
 class HashTest extends TestSupport
 {
-
     public function testIhmacSanity()
     {
         // Make sure at least one hash always happens with any kind of crazy cost value
@@ -58,7 +57,9 @@ class HashTest extends TestSupport
     {
         $input = 'hello world';
         $key = 'password';
-        $vector = base64_decode('dvvWMEFPCo9EV+l+htGGcoK5Uj8zrh6bfxCh16NOjJxuugObuidTQ3+R3qiyZLnHl7zRxSmfHRasEJQpTymZDw==');
+        $vector = base64_decode(
+            'dvvWMEFPCo9EV+l+htGGcoK5Uj8zrh6bfxCh16NOjJxuugObuidTQ3+R3qiyZLnHl7zRxSmfHRasEJQpTymZDw=='
+        );
         $this->assertTrue(Hash::verify($input, $vector, $key));
     }
 }

--- a/tests/Unit/EncrypterTest.php
+++ b/tests/Unit/EncrypterTest.php
@@ -8,7 +8,6 @@ use Rareloop\Lumberjack\Test\TestCase;
 use Rareloop\Lumberjack\Config;
 use Rareloop\Lumberjack\Encrypter;
 use PHPUnit\Framework\Attributes\Test;
-
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 
@@ -71,7 +70,7 @@ class EncrypterTest extends TestCase
     #[Test]
     public function can_process_objects()
     {
-        $payload = new \stdClass;
+        $payload = new \stdClass();
         $payload->foo = 'bar';
         $encrypter = new Encrypter('secret-key');
 

--- a/tests/Unit/Exceptions/HandlerTest.php
+++ b/tests/Unit/Exceptions/HandlerTest.php
@@ -13,7 +13,6 @@ use Rareloop\Lumberjack\Exceptions\Handler;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Diactoros\ServerRequest;
 use Rareloop\Lumberjack\FacadeFactory;
-
 use Spatie\Ignition\Ignition;
 use Spatie\FlareClient\Report;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -28,7 +27,7 @@ class HandlerTest extends TestCase
     #[Test]
     public function report_should_log_exception()
     {
-        $app = new Application;
+        $app = new Application();
 
         $exception = new \Exception('Test Exception');
 
@@ -44,7 +43,7 @@ class HandlerTest extends TestCase
     #[Test]
     public function blacklisted_exception_types_will_not_be_logged()
     {
-        $app = new Application;
+        $app = new Application();
 
         $exception = new BlacklistedException('Test Exception');
 
@@ -60,9 +59,9 @@ class HandlerTest extends TestCase
     #[Test]
     public function render_should_use_ignition_when_debug_is_enabled()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
-        $config = new Config;
+        $config = new Config();
         $config->set('app.debug', true);
         $app->bind('config', $config);
 
@@ -76,7 +75,7 @@ class HandlerTest extends TestCase
         $exception = new \Exception('Test Exception');
         $handler = new Handler($app);
 
-        $request = new ServerRequest;
+        $request = new ServerRequest();
 
         $response = $handler->render($request, $exception);
 
@@ -87,9 +86,9 @@ class HandlerTest extends TestCase
     #[Test]
     public function render_should_return_an_html_response_when_debug_is_disabled()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
-        $config = new Config;
+        $config = new Config();
         $config->set('app.debug', false);
         $app->bind('config', $config);
 
@@ -99,7 +98,7 @@ class HandlerTest extends TestCase
         $exception = new \Exception('Test Exception');
         $handler = new Handler($app);
 
-        $response = $handler->render(new ServerRequest, $exception);
+        $response = $handler->render(new ServerRequest(), $exception);
 
         $this->assertInstanceOf(HtmlResponse::class, $response);
         $this->assertSame('Lumberjack | 500', $response->getBody()->getContents());
@@ -108,9 +107,9 @@ class HandlerTest extends TestCase
     #[Test]
     public function render_should_include_stack_trace_when_debug_is_enabled()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
-        $config = new Config;
+        $config = new Config();
         $config->set('app.debug', true);
         $app->bind('config', $config);
 
@@ -124,7 +123,7 @@ class HandlerTest extends TestCase
         $exception = new \Exception('Test Exception');
         $handler = new Handler($app);
 
-        $response = $handler->render(new ServerRequest, $exception);
+        $response = $handler->render(new ServerRequest(), $exception);
 
         $this->assertStringContainsString('Test Exception', $response->getBody()->getContents());
     }
@@ -132,9 +131,9 @@ class HandlerTest extends TestCase
     #[Test]
     public function render_should_not_include_stack_trace_when_debug_is_disabled()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
-        $config = new Config;
+        $config = new Config();
         $config->set('app.debug', false);
         $app->bind('config', $config);
 
@@ -144,7 +143,7 @@ class HandlerTest extends TestCase
         $exception = new \Exception('Test Exception');
         $handler = new Handler($app);
 
-        $response = $handler->render(new ServerRequest, $exception);
+        $response = $handler->render(new ServerRequest(), $exception);
 
         $this->assertStringNotContainsString('Test Exception', $response->getBody()->getContents());
     }
@@ -152,9 +151,9 @@ class HandlerTest extends TestCase
     #[Test]
     public function render_uses_get_status_code_if_method_exists()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
-        $config = new Config;
+        $config = new Config();
         $config->set('app.debug', false);
         $app->bind('config', $config);
 
@@ -167,7 +166,7 @@ class HandlerTest extends TestCase
         $exception = new ExceptionWithStatusCode('Test Exception', 404);
         $handler = new Handler($app);
 
-        $response = $handler->render(new ServerRequest, $exception);
+        $response = $handler->render(new ServerRequest(), $exception);
 
         $this->assertSame(404, $response->getStatusCode());
         $this->assertSame('Lumberjack | 404', $response->getBody()->getContents());
@@ -197,4 +196,6 @@ class HandlerWithBlacklist extends Handler
     ];
 }
 
-class BlacklistedException extends \Exception {}
+class BlacklistedException extends \Exception
+{
+}

--- a/tests/Unit/GlobalFunctionsTest.php
+++ b/tests/Unit/GlobalFunctionsTest.php
@@ -7,7 +7,6 @@ use Rareloop\Lumberjack\Test\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Rareloop\Lumberjack\Helpers;
-
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -31,7 +31,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_retrieve_the_container_instance()
     {
-        $app = new Application;
+        $app = new Application();
 
         $this->assertSame($app, Helpers::app());
     }
@@ -39,7 +39,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_resolve_something_from_the_container()
     {
-        $app = new Application;
+        $app = new Application();
         $app->bind('test', 123);
 
         $this->assertSame(123, Helpers::app('test'));
@@ -48,7 +48,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_retrieve_a_config_value()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $config = new Config();
@@ -61,7 +61,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_retrieve_a_default_when_no_config_value_is_set()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $config = new Config();
@@ -73,7 +73,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_set_a_config_value_when_array_passed_to_config_helper()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
         $config = new Config();
         $app->bind('config', $config);
@@ -139,10 +139,11 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_get_a_url_for_a_named_route()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
-        $router = new Router;
-        $router->get('test/route', function () {})->name('test.route');
+        $router = new Router();
+        $router->get('test/route', function () {
+        })->name('test.route');
         $app->bind('router', $router);
 
         $url = Helpers::route('test.route');
@@ -153,10 +154,11 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_get_a_url_for_a_named_route_with_params()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
-        $router = new Router;
-        $router->get('test/{name}', function ($name) {})->name('test.route');
+        $router = new Router();
+        $router->get('test/{name}', function ($name) {
+        })->name('test.route');
         $app->bind('router', $router);
 
         $url = Helpers::route('test.route', [
@@ -201,7 +203,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_report_an_exception()
     {
-        $app = new Application;
+        $app = new Application();
         $exception = new \Exception('Testing 123');
         $handler = \Mockery::mock(TestExceptionHandler::class . '[report]', [$app]);
         $handler->shouldReceive('report')->with($exception)->once();
@@ -216,7 +218,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_access_an_item_in_the_session_by_key()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $store = new SessionManager($app);
@@ -230,7 +232,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_access_an_item_in_the_session_by_key_with_default()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $store = new SessionManager($app);
@@ -242,7 +244,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_add_an_item_in_the_session()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $store = new SessionManager($app);
@@ -256,7 +258,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_add_multiple_items_to_the_session()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $store = new SessionManager($app);
@@ -271,7 +273,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_resolve_the_session_manager()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $store = new SessionManager($app);
@@ -283,7 +285,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_redirect_back()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
         $store = new SessionManager($app);
         $app->bind('session', $store);
@@ -298,7 +300,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_get_server_request()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $request = new ServerRequest([], [], '/test/123', 'GET');
@@ -310,7 +312,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_get_logger()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $logger = new Logger('app');
@@ -325,7 +327,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_write_debug_log()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $logger = \Mockery::mock(Logger::class)->makePartial();
@@ -339,7 +341,7 @@ class HelpersTest extends TestCase
     #[Test]
     public function can_write_debug_log_with_context()
     {
-        $app = new Application;
+        $app = new Application();
         FacadeFactory::setContainer($app);
 
         $logger = \Mockery::mock(Logger::class)->makePartial();
@@ -374,5 +376,7 @@ class TestExceptionHandler extends Handler
 
 class RequiresConstructorParams
 {
-    public function __construct(public $param1, public $param2) {}
+    public function __construct(public $param1, public $param2)
+    {
+    }
 }

--- a/tests/Unit/Http/Middleware/PasswordProtectTest.php
+++ b/tests/Unit/Http/Middleware/PasswordProtectTest.php
@@ -26,7 +26,7 @@ class PasswordProtectTest extends TestCase
     #[Test]
     public function it_does_nothing_when_password_is_not_required()
     {
-        $middleware = new PasswordProtected;
+        $middleware = new PasswordProtected();
 
         Functions\expect('post_password_required')
             ->once()
@@ -44,7 +44,7 @@ class PasswordProtectTest extends TestCase
     #[Test]
     public function it_does_nothing_when_the_password_twig_file_is_not_found()
     {
-        $middleware = new PasswordProtected;
+        $middleware = new PasswordProtected();
 
         Functions\expect('post_password_required')
             ->once()
@@ -97,7 +97,7 @@ class PasswordProtectTest extends TestCase
 
         $handler->shouldReceive('handle')->never();
 
-        $middleware = new PasswordProtected;
+        $middleware = new PasswordProtected();
         $response = $middleware->process($request, $handler);
 
         $this->assertInstanceOf(TimberResponse::class, $response);

--- a/tests/Unit/Http/MiddlewareAliasStoreTest.php
+++ b/tests/Unit/Http/MiddlewareAliasStoreTest.php
@@ -16,7 +16,7 @@ class MiddlewareAliasStoreTest extends TestCase
     #[Test]
     public function can_register_an_alias_for_a_middleware_object()
     {
-        $store = new MiddlewareAliasStore;
+        $store = new MiddlewareAliasStore();
         $middleware = Mockery::mock(MiddlewareInterface::class);
 
         $store->set('middlewarekey', $middleware);
@@ -27,7 +27,7 @@ class MiddlewareAliasStoreTest extends TestCase
     #[Test]
     public function can_register_an_alias_for_a_middleware_closure_factory()
     {
-        $store = new MiddlewareAliasStore;
+        $store = new MiddlewareAliasStore();
         $middleware = Mockery::mock(MiddlewareInterface::class);
 
         $store->set('middlewarekey', function () use ($middleware) {
@@ -50,7 +50,7 @@ class MiddlewareAliasStoreTest extends TestCase
     #[Test]
     public function can_register_an_alias_with_params_for_a_middleware_closure_factory()
     {
-        $store = new MiddlewareAliasStore;
+        $store = new MiddlewareAliasStore();
         $middleware = Mockery::mock(MiddlewareInterface::class);
 
         $store->set('middlewarekey', function ($param1, $param2) use ($middleware) {
@@ -65,7 +65,7 @@ class MiddlewareAliasStoreTest extends TestCase
     #[Test]
     public function can_register_an_alias_with_params_for_a_classname()
     {
-        $store = new MiddlewareAliasStore;
+        $store = new MiddlewareAliasStore();
 
         $store->set('middlewarekey', MASTestClassWithConstructorParams::class);
         $middleware = $store->get('middlewarekey:123,abc');
@@ -78,7 +78,7 @@ class MiddlewareAliasStoreTest extends TestCase
     #[Test]
     public function can_check_if_alias_exists()
     {
-        $store = new MiddlewareAliasStore;
+        $store = new MiddlewareAliasStore();
         $middleware = Mockery::mock(MiddlewareInterface::class);
 
         $this->assertFalse($store->has('middlewarekey'));
@@ -91,7 +91,7 @@ class MiddlewareAliasStoreTest extends TestCase
     #[Test]
     public function can_check_if_alias_exists_when_string_contains_params()
     {
-        $store = new MiddlewareAliasStore;
+        $store = new MiddlewareAliasStore();
         $middleware = Mockery::mock(MiddlewareInterface::class);
 
         $this->assertFalse($store->has('middlewarekey'));
@@ -102,9 +102,13 @@ class MiddlewareAliasStoreTest extends TestCase
     }
 }
 
-class MASTestClass {}
+class MASTestClass
+{
+}
 
 class MASTestClassWithConstructorParams
 {
-    public function __construct(public $param1, public $param2) {}
+    public function __construct(public $param1, public $param2)
+    {
+    }
 }

--- a/tests/Unit/Http/MiddlewareResolverTest.php
+++ b/tests/Unit/Http/MiddlewareResolverTest.php
@@ -17,10 +17,10 @@ class MiddlewareResolverTest extends TestCase
     #[Test]
     public function can_resolve_a_key_from_the_container()
     {
-        $app = new Application;
-        $resolver = new MiddlewareResolver($app, new MiddlewareAliasStore);
+        $app = new Application();
+        $resolver = new MiddlewareResolver($app, new MiddlewareAliasStore());
 
-        $datetime = new \DateTime;
+        $datetime = new \DateTime();
         $app->bind('datetime', $datetime);
 
         $this->assertSame($datetime, $resolver->resolve('datetime'));
@@ -29,8 +29,8 @@ class MiddlewareResolverTest extends TestCase
     #[Test]
     public function can_resolve_an_object_from_a_classname_from_the_container()
     {
-        $app = new Application;
-        $resolver = new MiddlewareResolver($app, new MiddlewareAliasStore);
+        $app = new Application();
+        $resolver = new MiddlewareResolver($app, new MiddlewareAliasStore());
 
         $this->assertInstanceOf(MRTestClass::class, $resolver->resolve(MRTestClass::class));
     }
@@ -38,10 +38,10 @@ class MiddlewareResolverTest extends TestCase
     #[Test]
     public function can_resolve_a_middleware_alias()
     {
-        $app = new Application;
+        $app = new Application();
         $store = Mockery::mock(MiddlewareAliases::class);
         $store->shouldReceive('has')->with('middlewarekey')->once()->andReturn(true);
-        $store->shouldReceive('get')->with('middlewarekey')->once()->andReturn(new MRTestClass);
+        $store->shouldReceive('get')->with('middlewarekey')->once()->andReturn(new MRTestClass());
         $resolver = new MiddlewareResolver($app, $store);
 
         $this->assertInstanceOf(MRTestClass::class, $resolver->resolve('middlewarekey'));
@@ -50,13 +50,15 @@ class MiddlewareResolverTest extends TestCase
     #[Test]
     public function non_string_values_are_returned_as_is()
     {
-        $app = new Application;
-        $resolver = new MiddlewareResolver($app, new MiddlewareAliasStore);
+        $app = new Application();
+        $resolver = new MiddlewareResolver($app, new MiddlewareAliasStore());
 
-        $datetime = new \DateTime;
+        $datetime = new \DateTime();
 
         $this->assertSame($datetime, $resolver->resolve($datetime));
     }
 }
 
-class MRTestClass {}
+class MRTestClass
+{
+}

--- a/tests/Unit/Http/ResponseEmitterTest.php
+++ b/tests/Unit/Http/ResponseEmitterTest.php
@@ -55,7 +55,8 @@ class ResponseEmitterTest extends TestCase
         $headerBuilder = new MockBuilder();
         $headerBuilder->setNamespace('Laminas\HttpHandlerRunner\Emitter')
             ->setName('header')
-            ->setFunction(function () {});
+            ->setFunction(function () {
+            });
         $headerMock = $headerBuilder->build();
         $headerMock->enable();
 

--- a/tests/Unit/Http/Responses/RedirectResponseTest.php
+++ b/tests/Unit/Http/Responses/RedirectResponseTest.php
@@ -49,7 +49,7 @@ class RedirectResponseTest extends TestCase
     #[Test]
     public function can_call_with_method_to_flash_data_to_the_session(): void
     {
-        $app = new Application;
+        $app = new Application();
         $session = Mockery::mock(SessionManager::class);
         $session->shouldReceive('flash')->with('key', 'value')->once();
         $session->shouldReceive('flash')->with('foo', 'bar')->once();
@@ -63,7 +63,7 @@ class RedirectResponseTest extends TestCase
     #[Test]
     public function can_call_with_method_to_flash_data_to_the_session_using_an_array(): void
     {
-        $app = new Application;
+        $app = new Application();
         $session = Mockery::mock(SessionManager::class);
         $session->shouldReceive('flash')->with([
             'key' => 'value',

--- a/tests/Unit/Http/Responses/TimberResponseTest.php
+++ b/tests/Unit/Http/Responses/TimberResponseTest.php
@@ -238,7 +238,7 @@ class TestViewModel extends ViewModel
 
     public static function createFromArray(array $array)
     {
-        $vm = new static;
+        $vm = new static();
 
         foreach ($array as $key => $value) {
             $vm->{$key} = $value;

--- a/tests/Unit/Http/RouterTest.php
+++ b/tests/Unit/Http/RouterTest.php
@@ -22,7 +22,7 @@ class RouterTest extends TestCase
     public function controller_has_namespace_added(): void
     {
         class_alias(RouterTestController::class, 'App\Http\Controllers\MyController');
-        $router = new Router;
+        $router = new Router();
 
         $route = $router->get('/test/123', 'MyController@test');
 
@@ -32,7 +32,7 @@ class RouterTest extends TestCase
     #[Test]
     public function controller_does_not_have_namespace_added_when_it_already_exists(): void
     {
-        $router = new Router;
+        $router = new Router();
 
         $route = $router->get('/test/123', RouterTestController::class . '@test');
 
@@ -42,8 +42,8 @@ class RouterTest extends TestCase
     #[Test]
     public function controller_does_not_have_namespace_added_when_it_is_callable(): void
     {
-        $router = new Router;
-        $controller = new RouterTestController;
+        $router = new Router();
+        $controller = new RouterTestController();
 
         $route = $router->get('/test/123', [$controller, 'test']);
 
@@ -53,10 +53,11 @@ class RouterTest extends TestCase
     #[Test]
     public function controller_does_not_have_namespace_added_when_it_is_closure(): void
     {
-        $router = new Router;
-        $controller = new RouterTestController;
+        $router = new Router();
+        $controller = new RouterTestController();
 
-        $route = $router->get('/test/123', function () {});
+        $route = $router->get('/test/123', function () {
+        });
 
         $this->assertSame('Closure', $route->getActionName());
     }
@@ -77,7 +78,7 @@ class RouterTest extends TestCase
     #[Test]
     public function can_extend_post_behaviour_with_mixin(): void
     {
-        Router::mixin(new RouterMixin);
+        Router::mixin(new RouterMixin());
 
         $queryBuilder = new Router();
 
@@ -87,7 +88,7 @@ class RouterTest extends TestCase
 
 class RouterMixin
 {
-    function testFunctionAddedByMixin()
+    public function testFunctionAddedByMixin()
     {
         return function () {
             return 'abc123';
@@ -97,5 +98,7 @@ class RouterMixin
 
 class RouterTestController
 {
-    public function test() {}
+    public function test()
+    {
+    }
 }

--- a/tests/Unit/Http/ServerRequestTest.php
+++ b/tests/Unit/Http/ServerRequestTest.php
@@ -18,7 +18,7 @@ class ServerRequestTest extends TestCase
     #[Test]
     public function request_is_prs7_compliant(): void
     {
-        $request = new ServerRequest;
+        $request = new ServerRequest();
 
         $this->assertInstanceOf(ServerRequestInterface::class, $request);
     }
@@ -26,7 +26,7 @@ class ServerRequestTest extends TestCase
     #[Test]
     public function request_uses_extension_traits(): void
     {
-        $request = new ServerRequest;
+        $request = new ServerRequest();
 
         $traits = array_keys(class_uses($request));
 
@@ -47,7 +47,14 @@ class ServerRequestTest extends TestCase
     #[Test]
     public function fromRequest_parses_json_requests(): void
     {
-        $request = new DiactorosServerRequest([], [], '/test/123', 'POST', 'data://text/plain,{"foo": "bar"}', ['Content-Type' => 'application/json']);
+        $request = new DiactorosServerRequest(
+            [],
+            [],
+            '/test/123',
+            'POST',
+            'data://text/plain,{"foo": "bar"}',
+            ['Content-Type' => 'application/json']
+        );
 
         $lumberjackRequest = ServerRequest::fromRequest($request);
 

--- a/tests/Unit/PostQueryBuilderTest.php
+++ b/tests/Unit/PostQueryBuilderTest.php
@@ -14,14 +14,14 @@ use Throwable;
 
 class PostQueryBuilderTest extends TestCase
 {
-    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration,
-        \Rareloop\Lumberjack\Test\Unit\Concerns\ArraySubsetAsserts;
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    use \Rareloop\Lumberjack\Test\Unit\Concerns\ArraySubsetAsserts;
 
     private Application $app;
 
     public function setUp(): void
     {
-        $this->app = new Application;
+        $this->app = new Application();
         $this->app->bind(QueryBuilderContract::class, QueryBuilder::class);
 
         parent::setUp();

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -18,8 +18,9 @@ use Timber\Timber;
 #[PreserveGlobalState(false)]
 class PostTest extends TestCase
 {
-    public $dummyData;
     use BrainMonkeyPHPUnitIntegration;
+
+    public $dummyData;
 
     #[Test]
     public function register_function_calls_register_post_type_when_post_type_and_config_are_provided()
@@ -30,7 +31,10 @@ class PostTest extends TestCase
 
         RegisterablePostType::register();
 
-        $this->assertNotFalse(has_filter('timber/post/classmap', [RegisterablePostType::class, 'filterTimberPostClassMap']));
+        $this->assertNotFalse(has_filter(
+            'timber/post/classmap',
+            [RegisterablePostType::class, 'filterTimberPostClassMap']
+        ));
     }
 
     #[Test]
@@ -57,7 +61,11 @@ class PostTest extends TestCase
 
         $output = RegisterablePostType::filterTimberPostClassMap($output);
 
-        $this->assertEqualsCanonicalizing(['another' => TimberPost::class, 'post' => Post::class, 'registerable_post_type' => RegisterablePostType::class], $output);
+        $this->assertEqualsCanonicalizing([
+            'another' => TimberPost::class,
+            'post' => Post::class,
+            'registerable_post_type' => RegisterablePostType::class,
+        ], $output);
     }
 
     #[Test]
@@ -196,7 +204,7 @@ class PostTest extends TestCase
     #[Test]
     public function can_extend_post_behaviour_with_mixin()
     {
-        Post::mixin(new PostMixin);
+        Post::mixin(new PostMixin());
 
         $post = new Post(null, true);
 
@@ -206,7 +214,7 @@ class PostTest extends TestCase
 
 class PostMixin
 {
-    function testFunctionAddedByMixin()
+    public function testFunctionAddedByMixin()
     {
         return function () {
             return 'abc123';

--- a/tests/Unit/Providers/CustomPostTypesServiceProviderTest.php
+++ b/tests/Unit/Providers/CustomPostTypesServiceProviderTest.php
@@ -21,7 +21,7 @@ class CustomPostTypesServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/..');
 
-        $config = new Config;
+        $config = new Config();
 
         $config->set('posttypes.register', [
             CustomPost1::class,

--- a/tests/Unit/Providers/EncryptionServiceProviderTest.php
+++ b/tests/Unit/Providers/EncryptionServiceProviderTest.php
@@ -18,7 +18,7 @@ class EncryptionServiceProviderTest extends TestCase
     #[Test]
     public function encryptor_is_registered_in_container_when_a_config_key_is_present(): void
     {
-        $config = new Config;
+        $config = new Config();
         $config->set('app.key', 'encryption-key');
 
         $app = new Application();

--- a/tests/Unit/Providers/IgnitionServiceProviderTest.php
+++ b/tests/Unit/Providers/IgnitionServiceProviderTest.php
@@ -21,7 +21,7 @@ class IgnitionServiceProviderTest extends TestCase
     #[Test]
     public function ignition_is_bound_as_a_singleton_in_the_container()
     {
-        $app = new Application;
+        $app = new Application();
         $config = new Config();
         $app->bind('config', $config);
 

--- a/tests/Unit/Providers/ImageSizesServiceProviderTest.php
+++ b/tests/Unit/Providers/ImageSizesServiceProviderTest.php
@@ -19,7 +19,7 @@ class ImageSizesServiceProviderTest extends TestCase
     public function single_image_size_should_be_set_from_config(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         $config->set('images.sizes', [
             [
@@ -42,7 +42,7 @@ class ImageSizesServiceProviderTest extends TestCase
     public function add_image_size_should_not_be_called_if_images_sizes_config_is_empty(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         $config->set('images.sizes', []);
 
@@ -57,7 +57,7 @@ class ImageSizesServiceProviderTest extends TestCase
     public function add_image_size_should_not_be_called_if_images_sizes_config_is_not_set(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         Functions\expect('add_image_size')
             ->times(0);
@@ -70,7 +70,7 @@ class ImageSizesServiceProviderTest extends TestCase
     public function crop_should_be_false_if_not_set(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         $config->set('images.sizes', [
             [
@@ -92,7 +92,7 @@ class ImageSizesServiceProviderTest extends TestCase
     public function multiple_image_sizes_should_be_set_from_config(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         $config->set('images.sizes', [
             [

--- a/tests/Unit/Providers/LogServiceProviderTest.php
+++ b/tests/Unit/Providers/LogServiceProviderTest.php
@@ -41,7 +41,7 @@ class LogServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/../');
 
-        $config = new Config;
+        $config = new Config();
         $app->bind('config', $config);
 
         $app->bootstrapWith([
@@ -56,7 +56,7 @@ class LogServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/../');
 
-        $config = new Config;
+        $config = new Config();
         $app->bind('config', $config);
 
         $app->bootstrapWith([
@@ -71,7 +71,7 @@ class LogServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/../');
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.logs.enabled', false);
         $config->set('app.logs.path', 'app.log');
         $app->bind('config', $config);
@@ -88,7 +88,7 @@ class LogServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/../');
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.logs.level', Level::Error);
         $app->bind('config', $config);
 
@@ -104,7 +104,7 @@ class LogServiceProviderTest extends TestCase
     {
         $app = new Application('/base/path');
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.logs.enabled', true);
         $config->set('app.logs.path', false);
         $app->bind('config', $config);
@@ -121,7 +121,7 @@ class LogServiceProviderTest extends TestCase
     {
         $app = new Application('/base/path');
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.logs.enabled', false);
         $config->set('app.logs.path', false);
         $app->bind('config', $config);
@@ -138,7 +138,7 @@ class LogServiceProviderTest extends TestCase
     {
         $app = new Application('/base/path');
 
-        $config = new Config;
+        $config = new Config();
         $config->set('app.logs.enabled', true);
         $config->set('app.logs.path', '/base/new.log');
         $app->bind('config', $config);

--- a/tests/Unit/Providers/MenusServiceProviderTest.php
+++ b/tests/Unit/Providers/MenusServiceProviderTest.php
@@ -19,7 +19,7 @@ class MenusServiceProviderTest extends TestCase
     public function add_theme_support_should_be_called_with_menus(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         $config->set('menus.menus', []);
 
@@ -35,7 +35,7 @@ class MenusServiceProviderTest extends TestCase
     public function single_menu_should_be_set_from_config(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         $config->set('menus.menus', [
             ['menu-name' => 'Menu Name'],
@@ -57,7 +57,7 @@ class MenusServiceProviderTest extends TestCase
     public function multiple_menus_should_be_set_from_config(): void
     {
         $app = new Application(__DIR__ . '/..');
-        $config = new Config;
+        $config = new Config();
 
         $config->set('menus.menus', [
             ['menu-name' => 'Menu Name'],

--- a/tests/Unit/Providers/QueryBuilderServiceProviderTest.php
+++ b/tests/Unit/Providers/QueryBuilderServiceProviderTest.php
@@ -16,7 +16,7 @@ class QueryBuilderServiceProviderTest extends TestCase
     #[Test]
     public function query_builder_is_registered_into_container(): void
     {
-        $app = new Application;
+        $app = new Application();
         $provider = new QueryBuilderServiceProvider($app);
 
         $provider->register();

--- a/tests/Unit/Providers/RouterServiceProviderTest.php
+++ b/tests/Unit/Providers/RouterServiceProviderTest.php
@@ -82,7 +82,8 @@ class RouterServiceProviderTest extends TestCase
         $store->set('middleware-key', new RSPAddHeaderMiddleware('X-Key', 'abc'));
         $request = new ServerRequest([], [], '/test/123', 'GET');
 
-        $router->get('/test/123', function () {})->middleware('middleware-key');
+        $router->get('/test/123', function () {
+        })->middleware('middleware-key');
         $response = $router->match($request);
 
         $this->assertTrue($response->hasHeader('X-Key'));
@@ -289,7 +290,9 @@ class RouterServiceProviderTest extends TestCase
 
 class RSPAddHeaderMiddleware implements MiddlewareInterface
 {
-    public function __construct(private $key, private $value) {}
+    public function __construct(private $key, private $value)
+    {
+    }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/tests/Unit/Providers/ServiceProviderTest.php
+++ b/tests/Unit/Providers/ServiceProviderTest.php
@@ -17,8 +17,8 @@ class ServiceProviderTest extends TestCase
     #[Test]
     public function can_merge_config_from_a_file(): void
     {
-        $config = new Config;
-        $app = new Application;
+        $config = new Config();
+        $app = new Application();
         $app->bind(Config::class, $config);
         $provider = new TestServiceProvider($app);
 
@@ -30,8 +30,8 @@ class ServiceProviderTest extends TestCase
     #[Test]
     public function existing_config_takes_priority_over_merged_values(): void
     {
-        $config = new Config;
-        $app = new Application;
+        $config = new Config();
+        $app = new Application();
         $app->bind(Config::class, $config);
         $provider = new TestServiceProvider($app);
 
@@ -42,4 +42,6 @@ class ServiceProviderTest extends TestCase
     }
 }
 
-class TestServiceProvider extends ServiceProvider {}
+class TestServiceProvider extends ServiceProvider
+{
+}

--- a/tests/Unit/Providers/ThemeSupportServiceProviderTest.php
+++ b/tests/Unit/Providers/ThemeSupportServiceProviderTest.php
@@ -20,7 +20,7 @@ class ThemeSupportServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/..');
 
-        $config = new Config;
+        $config = new Config();
 
         $config->set('app.themeSupport', [
             'post-thumbnail',
@@ -39,7 +39,7 @@ class ThemeSupportServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/..');
 
-        $config = new Config;
+        $config = new Config();
 
         $config->set('app.themeSupport', [
             'post-formats' => ['aside', 'gallery'],

--- a/tests/Unit/Providers/TimberServiceProviderTest.php
+++ b/tests/Unit/Providers/TimberServiceProviderTest.php
@@ -15,7 +15,6 @@ use Rareloop\Lumberjack\Bootstrappers\BootProviders;
 use Rareloop\Lumberjack\Bootstrappers\RegisterProviders;
 use Rareloop\Lumberjack\Providers\TimberServiceProvider;
 use Rareloop\Lumberjack\Test\Unit\Concerns\BrainMonkeyPHPUnitIntegration;
-
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 
@@ -45,7 +44,7 @@ class TimberServiceProviderTest extends TestCase
     {
         $app = new Application(__DIR__ . '/../');
 
-        $config = new Config;
+        $config = new Config();
         $config->set('timber.paths', [
             'path/one',
             'path/two',

--- a/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
+++ b/tests/Unit/Providers/WordPressControllersServiceProviderTest.php
@@ -25,7 +25,7 @@ use Rareloop\Lumberjack\Test\Unit\Concerns\BrainMonkeyPHPUnitIntegration;
 use Rareloop\Router\Responsable;
 use Laminas\Diactoros\Response\TextResponse;
 use Laminas\Diactoros\ServerRequest;
-use \Mockery;
+use Mockery;
 use Rareloop\Lumberjack\Http\Middleware\PasswordProtected;
 
 class WordPressControllersServiceProviderTest extends TestCase
@@ -111,7 +111,10 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app = new Application(__DIR__ . '/../');
         $provider = new WordPressControllersServiceProvider($app);
 
-        $this->assertSame('App\\Error404Controller', $provider->getControllerClassFromTemplate(__DIR__ . 'includes/404.php'));
+        $this->assertSame(
+            'App\\Error404Controller',
+            $provider->getControllerClassFromTemplate(__DIR__ . 'includes/404.php')
+        );
     }
 
     #[Test]
@@ -137,7 +140,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app = new Application(__DIR__ . '/../');
         $provider = new WordPressControllersServiceProvider($app);
 
-        $response = $provider->handleRequest(new ServerRequest, 'Does\\Not\\Exist', 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), 'Does\\Not\\Exist', 'handle');
 
         $this->assertFalse($response);
     }
@@ -153,7 +156,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, 'Does\\Not\\Exist', 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), 'Does\\Not\\Exist', 'handle');
     }
 
     #[Test]
@@ -168,7 +171,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestController::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestController::class, 'handle');
 
         $this->assertTrue($app->hasRequestBeenHandled());
     }
@@ -181,7 +184,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, 'Does\\Not\\Exist', 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), 'Does\\Not\\Exist', 'handle');
 
         $this->assertFalse($app->hasRequestBeenHandled());
     }
@@ -198,7 +201,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestController::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestController::class, 'handle');
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
     }
@@ -215,7 +218,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerReturningAResponsable::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerReturningAResponsable::class, 'handle');
 
         $this->assertInstanceOf(TextResponse::class, $response);
         $this->assertSame('testing123', $response->getBody()->getContents());
@@ -233,7 +236,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerWithConstructorParams::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerWithConstructorParams::class, 'handle');
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
     }
@@ -250,7 +253,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerWithHandleParams::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerWithHandleParams::class, 'handle');
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
     }
@@ -263,14 +266,14 @@ class WordPressControllersServiceProviderTest extends TestCase
             ->andReturn(false);
 
         $app = new Application(__DIR__ . '/../');
-        $controller = new TestControllerWithMiddleware;
+        $controller = new TestControllerWithMiddleware();
         $controller->middleware(new AddHeaderMiddleware('X-Header', 'testing123'));
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerWithMiddleware::class, 'handle');
 
         $this->assertTrue($response->hasHeader('X-Header'));
         $this->assertSame('testing123', $response->getHeader('X-Header')[0]);
@@ -285,13 +288,13 @@ class WordPressControllersServiceProviderTest extends TestCase
         $app = new Application(__DIR__ . '/../');
         $app->bind(PasswordProtected::class, $mock);
 
-        $controller = new TestControllerWithMiddleware;
+        $controller = new TestControllerWithMiddleware();
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerWithMiddleware::class, 'handle');
 
         $this->assertSame('password-protected', $response->getBody()->getContents());
     }
@@ -304,14 +307,14 @@ class WordPressControllersServiceProviderTest extends TestCase
             ->andReturn(false);
 
         $app = new Application(__DIR__ . '/../');
-        $controller = new TestControllerWithMiddleware;
+        $controller = new TestControllerWithMiddleware();
         $controller->middleware(new AddHeaderMiddleware('X-Header', 'testing123'))->only('notHandle');
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerWithMiddleware::class, 'handle');
 
         $this->assertFalse($response->hasHeader('X-Header'));
     }
@@ -324,14 +327,14 @@ class WordPressControllersServiceProviderTest extends TestCase
             ->andReturn(false);
 
         $app = new Application(__DIR__ . '/../');
-        $controller = new TestControllerWithMiddleware;
+        $controller = new TestControllerWithMiddleware();
         $controller->middleware(new AddHeaderMiddleware('X-Header', 'testing123'))->except('handle');
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
         $provider = new WordPressControllersServiceProvider($app);
         $provider->boot();
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerWithMiddleware::class, 'handle');
 
         $this->assertFalse($response->hasHeader('X-Header'));
     }
@@ -351,7 +354,7 @@ class WordPressControllersServiceProviderTest extends TestCase
 
         $app = new Application(__DIR__ . '/../');
 
-        $controller = new TestControllerWithMiddleware;
+        $controller = new TestControllerWithMiddleware();
         $controller->middleware('middleware-key');
         $app->bind(TestControllerWithMiddleware::class, $controller);
 
@@ -364,7 +367,7 @@ class WordPressControllersServiceProviderTest extends TestCase
         $store = $app->get(MiddlewareAliases::class);
         $store->set('middleware-key', new AddHeaderMiddleware('X-Header', 'testing123'));
 
-        $response = $provider->handleRequest(new ServerRequest, TestControllerWithMiddleware::class, 'handle');
+        $response = $provider->handleRequest(new ServerRequest(), TestControllerWithMiddleware::class, 'handle');
 
         $this->assertTrue($response->hasHeader('X-Header'));
         $this->assertSame('testing123', $response->getHeader('X-Header')[0]);
@@ -400,19 +403,27 @@ class WordPressControllersServiceProviderTest extends TestCase
 
 class TestController
 {
-    public function handle() {}
+    public function handle()
+    {
+    }
 }
 
 class TestControllerWithConstructorParams
 {
-    public function __construct(Application $app) {}
+    public function __construct(Application $app)
+    {
+    }
 
-    public function handle() {}
+    public function handle()
+    {
+    }
 }
 
 class TestControllerWithHandleParams
 {
-    public function handle(Application $app) {}
+    public function handle(Application $app)
+    {
+    }
 }
 
 class MyResponsable implements Responsable
@@ -427,18 +438,22 @@ class TestControllerReturningAResponsable
 {
     public function handle()
     {
-        return new MyResponsable;
+        return new MyResponsable();
     }
 }
 
 class TestControllerWithMiddleware extends Controller
 {
-    public function handle() {}
+    public function handle()
+    {
+    }
 }
 
 class AddHeaderMiddleware implements MiddlewareInterface
 {
-    public function __construct(private $key, private $value) {}
+    public function __construct(private $key, private $value)
+    {
+    }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -17,12 +17,13 @@ use Timber\Timber;
 
 class QueryBuilderTest extends TestCase
 {
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    use \Rareloop\Lumberjack\Test\Unit\Concerns\ArraySubsetAsserts;
+
     /**
      * @var array<string, string>
      */
     public $params;
-    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration,
-        \Rareloop\Lumberjack\Test\Unit\Concerns\ArraySubsetAsserts;
 
     #[Test]
     public function correct_post_type_is_set()
@@ -495,7 +496,7 @@ class QueryBuilderTest extends TestCase
     #[Test]
     public function can_extend_querybuilder_behaviour_with_mixin()
     {
-        QueryBuilder::mixin(new QueryBuilderMixin);
+        QueryBuilder::mixin(new QueryBuilderMixin());
 
         $queryBuilder = new QueryBuilder();
 
@@ -511,7 +512,8 @@ class QueryBuilderMixin
      * @var array<string, string>
      */
     public $params;
-    function testFunctionAddedByMixin()
+
+    public function testFunctionAddedByMixin()
     {
         return function () {
             $this->params['foo'] = 'bar';

--- a/tests/Unit/ScopedQueryBuilderTest.php
+++ b/tests/Unit/ScopedQueryBuilderTest.php
@@ -16,24 +16,24 @@ use Rareloop\Lumberjack\QueryBuilder;
 use Rareloop\Lumberjack\ScopedQueryBuilder;
 use Rareloop\Lumberjack\Contracts\QueryBuilder as QueryBuilderContract;
 use Rareloop\Lumberjack\Test\Unit\Concerns\ArraySubsetAsserts;
-
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 
 class ScopedQueryBuilderTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+    use ArraySubsetAsserts;
+
     /**
      * @var array<string, string>
      */
     public $params;
-    use MockeryPHPUnitIntegration,
-        ArraySubsetAsserts;
 
     private Application $app;
 
     public function setUp(): void
     {
-        $this->app = new Application;
+        $this->app = new Application();
         $this->app->bind(QueryBuilderContract::class, QueryBuilder::class);
 
         parent::setUp();

--- a/tests/Unit/Session/EncryptedStoreTest.php
+++ b/tests/Unit/Session/EncryptedStoreTest.php
@@ -27,7 +27,7 @@ class EncryptedStoreTest extends TestCase
             return $array['foo'] === 'bar';
         })->once();
 
-        $store = new EncryptedStore('session-name', new NullSessionHandler, $encrypter, 'session-id');
+        $store = new EncryptedStore('session-name', new NullSessionHandler(), $encrypter, 'session-id');
 
         $store->put('foo', 'bar');
 
@@ -65,7 +65,13 @@ class EncryptedStoreTest extends TestCase
         $errorHandler = Mockery::mock(HandlerInterface::class);
         $errorHandler->shouldReceive('report')->once();
 
-        $store = new EncryptedStore('session-name', $handler, new Encrypter($encryptionKey), 'session-id', $errorHandler);
+        $store = new EncryptedStore(
+            'session-name',
+            $handler,
+            new Encrypter($encryptionKey),
+            'session-id',
+            $errorHandler
+        );
         $store->start();
 
         $this->assertSame(null, $store->get('foo'));
@@ -98,7 +104,13 @@ class EncryptedStoreTest extends TestCase
         $errorHandler = Mockery::mock(HandlerInterface::class);
         $errorHandler->shouldNotHaveReceived('report');
 
-        $store = new EncryptedStore('session-name', $handler, new Encrypter($encryptionKey), 'session-id', $errorHandler);
+        $store = new EncryptedStore(
+            'session-name',
+            $handler,
+            new Encrypter($encryptionKey),
+            'session-id',
+            $errorHandler
+        );
         $store->start();
 
         $this->assertSame(null, $store->get('foo'));

--- a/tests/Unit/Session/SessionManagerTest.php
+++ b/tests/Unit/Session/SessionManagerTest.php
@@ -29,8 +29,8 @@ class SessionManagerTest extends TestCase
 
     private function appWithSessionDriverConfig($driver, $cookie = 'lumberjack', $encrypted = false)
     {
-        $app = new Application;
-        $config = new Config;
+        $app = new Application();
+        $config = new Config();
 
         $config->set('session.cookie', $cookie);
         $config->set('session.driver', $driver);
@@ -79,11 +79,11 @@ class SessionManagerTest extends TestCase
     #[Test]
     public function can_extend_list_of_drivers()
     {
-        $app = new Application;
+        $app = new Application();
         $manager = new SessionManager($app);
 
         $manager->extend('test', function () {
-            return new Store('name', new TestSessionHandler);
+            return new Store('name', new TestSessionHandler());
         });
 
         $this->assertInstanceOf(TestSessionHandler::class, $manager->driver('test')->getHandler());
@@ -119,4 +119,6 @@ class SessionManagerTest extends TestCase
     }
 }
 
-class TestSessionHandler extends NullSessionHandler {}
+class TestSessionHandler extends NullSessionHandler
+{
+}

--- a/tests/Unit/Session/StoreTest.php
+++ b/tests/Unit/Session/StoreTest.php
@@ -11,8 +11,8 @@ use Rareloop\Lumberjack\Test\Unit\Session\NullSessionHandler;
 
 class StoreTest extends TestCase
 {
-    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration,
-        \Rareloop\Lumberjack\Test\Unit\Concerns\ArraySubsetAsserts;
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+    use \Rareloop\Lumberjack\Test\Unit\Concerns\ArraySubsetAsserts;
 
     public static function chainableMethods(): array
     {
@@ -34,7 +34,7 @@ class StoreTest extends TestCase
     #[DataProvider('chainableMethods')]
     public function public_methods_are_chainable($methodName, ...$params)
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $this->assertSame($store, $store->{$methodName}(...$params));
     }
@@ -42,7 +42,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_get_session_name()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $this->assertSame('session-name', $store->getName());
     }
@@ -50,7 +50,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_get_session_id()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $this->assertSame('session-id', $store->getId());
     }
@@ -58,7 +58,7 @@ class StoreTest extends TestCase
     #[Test]
     public function id_is_generated_if_none_is_provided()
     {
-        $store = new Store('session-name', new NullSessionHandler);
+        $store = new Store('session-name', new NullSessionHandler());
 
         $this->assertNotNull($store->getId());
         $this->assertEquals(40, strlen($store->getId()));
@@ -67,7 +67,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_put_a_single_key_value_pair()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->put('foo', 'bar');
 
@@ -77,7 +77,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_put_a_single_key_value_pair_as_array()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->put(['foo' => 'bar']);
 
@@ -87,7 +87,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_get_a_default_value_if_none_is_present()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $this->assertSame(null, $store->get('foo'));
         $this->assertSame('bar', $store->get('foo', 'bar'));
@@ -96,7 +96,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_get_all_values()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->put('foo1', 'bar1');
         $store->put('foo2', 'bar2');
@@ -110,7 +110,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_check_if_session_has_a_value_set()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->put('foo', 'bar');
 
@@ -121,7 +121,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_pull_a_value()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->put('foo', 'bar');
         $this->assertTrue($store->has('foo'));
@@ -135,7 +135,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_push_a_value_into_an_array_when_not_previously_set()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->push('foo', 'bar');
 
@@ -145,7 +145,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_push_a_value_into_an_array_when_it_already_exists()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->put('foo', ['bar1']);
         $store->push('foo', 'bar2');
@@ -156,7 +156,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_forget_a_single_value()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->push('foo', 'bar');
 
@@ -170,7 +170,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_forget_multiple_values()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->push('foo1', 'bar1');
         $store->push('foo2', 'bar2');
@@ -187,7 +187,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_flush_all_values()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->push('foo1', 'bar1');
         $store->push('foo2', 'bar2');
@@ -234,7 +234,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_flash_values_into_the_session_using_array_syntax()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash([
             'key' => 'value',
@@ -248,7 +248,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_flash_a_value_into_the_session()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash('foo', 'bar');
 
@@ -258,7 +258,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_read_flash_value_after_one_save()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash('foo', 'bar');
         $store->save();
@@ -269,7 +269,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_not_read_flash_value_after_two_saves()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash('foo', 'bar');
         $store->save();
@@ -281,7 +281,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_flash_the_same_key_on_consecutive_sessions()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash('foo', 'bar');
         $store->save();
@@ -295,7 +295,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_reflash_data()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash('foo1', 'bar1');
         $store->flash('foo2', 'bar2');
@@ -315,7 +315,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_keep_a_single_key()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash('foo1', 'bar1');
         $store->flash('foo2', 'bar2');
@@ -333,7 +333,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_keep_multiple_keys()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->flash('foo1', 'bar1');
         $store->flash('foo2', 'bar2');
@@ -351,7 +351,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_get_handler()
     {
-        $handler = new NullSessionHandler;
+        $handler = new NullSessionHandler();
         $store = new Store('session-name', $handler, 'session-id');
 
         $this->assertSame($handler, $store->getHandler());
@@ -360,7 +360,7 @@ class StoreTest extends TestCase
     #[Test]
     public function can_store_previous_url()
     {
-        $store = new Store('session-name', new NullSessionHandler, 'session-id');
+        $store = new Store('session-name', new NullSessionHandler(), 'session-id');
 
         $store->setPreviousUrl('/a/valid/route');
 


### PR DESCRIPTION
# CI Overhaul

This PR introduces a large overhaul to our CI pipeline, to tighten it up and improve DX going forwards.

## CI Changes

* Scoped push events to master and added a concurrency group with `cancel-in-progress: true` to prevent redundant builds.
* Explicitly restricted job permissions to `contents: read`.
* Refactored the strategy matrix to use `dependency_type` (stable vs. lowest) and disabled fail-fast to ensure complete tests across all versions which is helpful for debugging.
* Migrated from `php-actions/composer` action to direct composer update CLI calls, saves a redundant docker container being spun up
* Replaced deprecated/commented Coveralls logic with CodeCoverageSummary, injecting a markdown report directly into the GitHub Job Summary (restricted to PHP 8.3 stable builds).
  * This addresses #47 - Coveralls is a dependency nightmare, so a leaner summary feels like a sensible direction to head in.
  * Example: https://github.com/Rareloop/lumberjack-core/actions/runs/25726781824

## Code changes

* Tightened PHPCS
* Fixed all codestyle issues

## Future work

We have made a note to add in PHPStan/similar in a future major release. This is because a full static analysis pass will result in a lot of breaking changes.