### PR TITLE
Prevent EmitterException when output buffer has content

### DIFF
--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -4,9 +4,17 @@ namespace Rareloop\Lumberjack\Http;
 
 use Psr\Http\Message\ResponseInterface;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 
 class ResponseEmitter
 {
+    protected EmitterInterface $emitter;
+
+    public function __construct(?EmitterInterface $emitter = null)
+    {
+        $this->emitter = $emitter ?? new SapiEmitter();
+    }
+
     /**
      * Emit a response.
      *
@@ -26,13 +34,33 @@ class ResponseEmitter
         // If the output buffer has content, SapiEmitter will throw an exception.
         // We circumvent this by stacking a new buffer, emitting into it,
         // and then echoing the result.
-        if (ob_get_level() > 0 && ob_get_length() > 0) {
-            ob_start();
-            (new SapiEmitter())->emit($response);
-            echo ob_get_clean();
+        if ($this->isOutputBufferDirty()) {
+            $this->emitWithStackedBuffer($response);
             return;
         }
 
-        (new SapiEmitter())->emit($response);
+        $this->emitter->emit($response);
+    }
+
+    /**
+     * Check if the output buffer has existing content.
+     */
+    protected function isOutputBufferDirty(): bool
+    {
+        return ob_get_level() > 0 && ob_get_length() > 0;
+    }
+
+    /**
+     * Emit the response into a clean buffer to bypass SapiEmitter's strict checks.
+     */
+    protected function emitWithStackedBuffer(ResponseInterface $response): void
+    {
+        ob_start();
+
+        try {
+            $this->emitter->emit($response);
+        } finally {
+            echo ob_get_clean();
+        }
     }
 }

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -23,6 +23,12 @@ class ResponseEmitter
             return;
         }
 
+        // If the output buffer has content, SapiEmitter will throw an exception.
+        // We can circumvent this by cleaning the buffer and echoing the content.
+        if (ob_get_level() > 0 && ob_get_length() > 0) {
+            echo ob_get_clean();
+        }
+
         (new SapiEmitter())->emit($response);
     }
 }

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -8,9 +8,7 @@ use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 
 class ResponseEmitter
 {
-    protected EmitterInterface $emitter;
-
-    public function __construct(?EmitterInterface $emitter = null)
+    public function __construct(protected ?EmitterInterface $emitter = null)
     {
         $this->emitter = $emitter ?? new SapiEmitter();
     }

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -24,9 +24,13 @@ class ResponseEmitter
         }
 
         // If the output buffer has content, SapiEmitter will throw an exception.
-        // We can circumvent this by cleaning the buffer and echoing the content.
+        // We circumvent this by stacking a new buffer, emitting into it,
+        // and then echoing the result.
         if (ob_get_level() > 0 && ob_get_length() > 0) {
+            ob_start();
+            (new SapiEmitter())->emit($response);
             echo ob_get_clean();
+            return;
         }
 
         (new SapiEmitter())->emit($response);

--- a/tests/Unit/Http/ResponseEmitterTest.php
+++ b/tests/Unit/Http/ResponseEmitterTest.php
@@ -84,4 +84,59 @@ class ResponseEmitterTest extends TestCase
         $headerMock->disable();
         $emitterHeadersSentMock->disable();
     }
+
+    #[Test]
+    public function emit_should_not_throw_exception_when_output_buffer_has_content_but_headers_not_sent(): void
+    {
+        $builder = new MockBuilder();
+        $builder->setNamespace('Rareloop\Lumberjack\Http')
+            ->setName('headers_sent')
+            ->setFunction(function () {
+                return false;
+            });
+        $mock = $builder->build();
+        $mock->enable();
+
+        // SapiEmitter uses the global header() function.
+        $headerBuilder = new MockBuilder();
+        $headerBuilder->setNamespace('Laminas\HttpHandlerRunner\Emitter')
+            ->setName('header')
+            ->setFunction(function () {
+            });
+        $headerMock = $headerBuilder->build();
+        $headerMock->enable();
+
+        // SapiEmitterTrait checks for namespaced headers_sent
+        $emitterHeadersSentBuilder = new MockBuilder();
+        $emitterHeadersSentBuilder->setNamespace('Laminas\HttpHandlerRunner\Emitter')
+            ->setName('headers_sent')
+            ->setFunction(function () {
+                return false;
+            });
+        $emitterHeadersSentMock = $emitterHeadersSentBuilder->build();
+        $emitterHeadersSentMock->enable();
+
+        $response = new TextResponse('Hello World');
+        $emitter = new ResponseEmitter();
+
+        // Start output buffering and put some content in it
+        ob_start();
+        echo 'Existing output';
+
+        // We expect no exception now
+        ob_start();
+        $emitter->emit($response);
+        $output = ob_get_clean();
+
+        // Final output should contain both existing and new content
+        // The outer buffer was started before 'Existing output'
+        $existing = ob_get_clean();
+
+        $this->assertSame('Hello World', $output);
+        $this->assertSame('Existing output', $existing);
+
+        $mock->disable();
+        $headerMock->disable();
+        $emitterHeadersSentMock->disable();
+    }
 }

--- a/tests/Unit/Http/ResponseEmitterTest.php
+++ b/tests/Unit/Http/ResponseEmitterTest.php
@@ -6,14 +6,14 @@ use Rareloop\Lumberjack\Test\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Rareloop\Lumberjack\Http\ResponseEmitter;
 use Laminas\Diactoros\Response\TextResponse;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
+use Mockery;
 use phpmock\MockBuilder;
 
-#[RunTestsInSeparateProcesses]
-#[PreserveGlobalState(false)]
 class ResponseEmitterTest extends TestCase
 {
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     #[Test]
     public function emit_should_echo_body_when_headers_sent(): void
     {
@@ -39,7 +39,7 @@ class ResponseEmitterTest extends TestCase
     }
 
     #[Test]
-    public function emit_should_use_sapi_emitter_when_headers_not_sent(): void
+    public function emit_should_use_provided_emitter_when_headers_not_sent(): void
     {
         $builder = new MockBuilder();
         $builder->setNamespace('Rareloop\Lumberjack\Http')
@@ -50,43 +50,19 @@ class ResponseEmitterTest extends TestCase
         $mock = $builder->build();
         $mock->enable();
 
-        // SapiEmitter uses the global header() function.
-        // We mock it in the SapiEmitter's namespace to prevent it from actually sending headers
-        $headerBuilder = new MockBuilder();
-        $headerBuilder->setNamespace('Laminas\HttpHandlerRunner\Emitter')
-            ->setName('header')
-            ->setFunction(function () {
-            });
-        $headerMock = $headerBuilder->build();
-        $headerMock->enable();
-
-        // SapiEmitterTrait checks for namespaced headers_sent
-        $emitterHeadersSentBuilder = new MockBuilder();
-        $emitterHeadersSentBuilder->setNamespace('Laminas\HttpHandlerRunner\Emitter')
-            ->setName('headers_sent')
-            ->setFunction(function () {
-                return false;
-            });
-        $emitterHeadersSentMock = $emitterHeadersSentBuilder->build();
-        $emitterHeadersSentMock->enable();
-
         $response = new TextResponse('Hello World');
-        $emitter = new ResponseEmitter();
+        $innerEmitter = Mockery::mock(EmitterInterface::class);
 
-        ob_start();
+        $innerEmitter->shouldReceive('emit')->once()->with($response)->andReturn(true);
+
+        $emitter = new ResponseEmitter($innerEmitter);
         $emitter->emit($response);
-        $output = ob_get_clean();
-
-        // SapiEmitter echoes the body, so we should see 'Hello World'
-        $this->assertSame('Hello World', $output);
 
         $mock->disable();
-        $headerMock->disable();
-        $emitterHeadersSentMock->disable();
     }
 
     #[Test]
-    public function emit_should_not_throw_exception_when_output_buffer_has_content_but_headers_not_sent(): void
+    public function emit_should_use_stacked_buffer_when_output_buffer_has_content_but_headers_not_sent(): void
     {
         $builder = new MockBuilder();
         $builder->setNamespace('Rareloop\Lumberjack\Http')
@@ -97,27 +73,17 @@ class ResponseEmitterTest extends TestCase
         $mock = $builder->build();
         $mock->enable();
 
-        // SapiEmitter uses the global header() function.
-        $headerBuilder = new MockBuilder();
-        $headerBuilder->setNamespace('Laminas\HttpHandlerRunner\Emitter')
-            ->setName('header')
-            ->setFunction(function () {
-            });
-        $headerMock = $headerBuilder->build();
-        $headerMock->enable();
-
-        // SapiEmitterTrait checks for namespaced headers_sent
-        $emitterHeadersSentBuilder = new MockBuilder();
-        $emitterHeadersSentBuilder->setNamespace('Laminas\HttpHandlerRunner\Emitter')
-            ->setName('headers_sent')
-            ->setFunction(function () {
-                return false;
-            });
-        $emitterHeadersSentMock = $emitterHeadersSentBuilder->build();
-        $emitterHeadersSentMock->enable();
-
         $response = new TextResponse('Hello World');
-        $emitter = new ResponseEmitter();
+        $innerEmitter = Mockery::mock(EmitterInterface::class);
+
+        // We expect the inner emitter to be called.
+        // We'll make it echo something to verify it's captured by the stacked buffer
+        $innerEmitter->shouldReceive('emit')->once()->with($response)->andReturnUsing(function () {
+            echo 'Hello World';
+            return true;
+        });
+
+        $emitter = new ResponseEmitter($innerEmitter);
 
         // Start output buffering and put some content in it
         ob_start();
@@ -125,14 +91,12 @@ class ResponseEmitterTest extends TestCase
 
         // We expect no exception now
         $emitter->emit($response);
-        
+
         // Final output should contain both existing and new content
         $output = ob_get_clean();
 
         $this->assertSame('Existing outputHello World', $output);
 
         $mock->disable();
-        $headerMock->disable();
-        $emitterHeadersSentMock->disable();
     }
 }

--- a/tests/Unit/Http/ResponseEmitterTest.php
+++ b/tests/Unit/Http/ResponseEmitterTest.php
@@ -124,16 +124,12 @@ class ResponseEmitterTest extends TestCase
         echo 'Existing output';
 
         // We expect no exception now
-        ob_start();
         $emitter->emit($response);
+        
+        // Final output should contain both existing and new content
         $output = ob_get_clean();
 
-        // Final output should contain both existing and new content
-        // The outer buffer was started before 'Existing output'
-        $existing = ob_get_clean();
-
-        $this->assertSame('Hello World', $output);
-        $this->assertSame('Existing output', $existing);
+        $this->assertSame('Existing outputHello World', $output);
 
         $mock->disable();
         $headerMock->disable();


### PR DESCRIPTION
If headers have not been sent but the output buffer is not empty, Laminas SapiEmitter throws an EmitterException. This commonly happens in WordPress when plugins (like Gravity Forms) leak output early.

We now detect this scenario, clean the buffer, and echo its content before calling SapiEmitter, ensuring all previous output is preserved while allowing the PSR-7 response to be emitted correctly.
